### PR TITLE
AXI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ STALL?=0
 test: firmware.hex testbench
 	vvp -N testbench +vcd +stall=$(STALL)
 
+test_axi: firmware.hex testbench_axi
+	vvp -N testbench_axi +vcd +stall=$(STALL)
+
 firmware.elf: firmware.s firmware.c
 	$(TOOLCHAIN_PREFIX)gcc -march=rv32i -mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $^
 
@@ -29,6 +32,9 @@ firmware.hex: firmware.elf
 	$(TOOLCHAIN_PREFIX)objcopy -O verilog $< $@
 
 testbench: testbench.sv nerv.sv
+	iverilog -g 2012 -o $@ -D NERV_DBGREGS $^
+
+testbench_axi: testbench_axi.sv nerv.sv nervaxi.sv
 	iverilog -g 2012 -o $@ -D NERV_DBGREGS $^
 
 check_axi_comb_paths: nervaxi.sv nerv.sv
@@ -46,6 +52,9 @@ check:
 
 show:
 	gtkwave testbench.vcd testbench.gtkw >> gtkwave.log 2>&1 &
+
+show_axi:
+	gtkwave testbench_axi.vcd testbench_axi.gtkw >> gtkwave.log 2>&1 &
 
 clean:
 	rm -rf firmware.elf firmware.hex testbench testbench.vcd gtkwave.log

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ firmware.hex: firmware.elf
 testbench: testbench.sv nerv.sv
 	iverilog -o testbench -D STALL -D NERV_DBGREGS testbench.sv nerv.sv
 
+check_axi_comb_paths: nervaxi.sv nerv.sv
+	 yosys -ql check_axi_comb_paths.log nervaxi.sv nerv.sv \
+		-p 'hierarchy -top nerv_axi_lite' \
+		-p 'proc; flatten; opt_dff' \
+		-p 'scc -expect 0' \
+		-p 'select -assert-none i:*mem_axi_* %co*:-$$dff o:*mem_axi_* %ci*:-$$dff %i'
+
 check:
 	python3 ../../checks/genchecks.py
 	$(MAKE) -C checks

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,10 @@
 
 TOOLCHAIN_PREFIX?=riscv64-unknown-elf-
 
+STALL?=0
+
 test: firmware.hex testbench
-	vvp -N testbench +vcd
+	vvp -N testbench +vcd +stall=$(STALL)
 
 firmware.elf: firmware.s firmware.c
 	$(TOOLCHAIN_PREFIX)gcc -march=rv32i -mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $^
@@ -27,7 +29,7 @@ firmware.hex: firmware.elf
 	$(TOOLCHAIN_PREFIX)objcopy -O verilog $< $@
 
 testbench: testbench.sv nerv.sv
-	iverilog -o testbench -D STALL -D NERV_DBGREGS testbench.sv nerv.sv
+	iverilog -g 2012 -o $@ -D NERV_DBGREGS $^
 
 check_axi_comb_paths: nervaxi.sv nerv.sv
 	 yosys -ql check_axi_comb_paths.log nervaxi.sv nerv.sv \

--- a/nervaxi.sby
+++ b/nervaxi.sby
@@ -1,0 +1,85 @@
+[tasks]
+prove : prove imem dmem
+prove-imem : prove imem
+prove-dmem : prove dmem
+cover : cover imem dmem
+cover-imem : cover imem
+cover-dmem : cover dmem
+
+prove : default
+
+[options]
+prove: mode prove
+cover: mode cover
+
+vcd_sim on
+
+[engines]
+prove: abc pdr
+cover: smtbmc boolector
+
+[script]
+# Read packages first
+# This one should be alwyas read first
+read -sv amba_axi4_protocol_checker_pkg.sv
+# Then the rest of them
+read -sv amba_axi4_single_interface_requirements.sv
+read -sv amba_axi4_definition_of_axi4_lite.sv
+read -sv amba_axi4_atomic_accesses.sv
+read -sv amba_axi4_transaction_structure.sv
+read -sv amba_axi4_transaction_attributes.sv
+read -sv amba_axi4_low_power_interface.sv
+read -sv amba_axi4_low_power_channel.sv
+
+# This is a checker, not a package
+read -sv amba_axi4_write_response_dependencies.sv
+read -sv amba_axi4_exclusive_access_source_perspective.sv
+
+# The modules containing the properties
+read -sv amba_axi4_protocol_checker.sv
+read -sv amba_axi4_read_address_channel.sv
+read -sv amba_axi4_read_data_channel.sv
+read -sv amba_axi4_write_data_channel.sv
+read -sv amba_axi4_write_response_channel.sv
+read -sv amba_axi4_write_address_channel.sv
+
+# Then the dut
+read -sv nerv.sv
+read -sv nervaxi.sv
+
+imem: read -define NERVAXI_CHECK_IMEM
+dmem: read -define NERVAXI_CHECK_DMEM
+
+# The bind file
+read -sv nervaxi_bind.sv
+
+# Elaborate
+prep -top nerv_axi_lite
+
+[files]
+# Packages
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_protocol_checker_pkg.sv
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_low_power_channel.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_spec/amba_axi4_single_interface_requirements.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_spec/amba_axi4_definition_of_axi4_lite.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_spec/amba_axi4_atomic_accesses.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_spec/amba_axi4_transaction_structure.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_spec/amba_axi4_transaction_attributes.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_spec/amba_axi4_low_power_interface.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_lib/amba_axi4_write_response_dependencies.sv
+../SVA-AXI4-FVIP/AXI4/src/axi4_lib/amba_axi4_exclusive_access_source_perspective.sv
+
+# Modules containing the properties
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_protocol_checker.sv
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_read_address_channel.sv
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_read_data_channel.sv
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_write_data_channel.sv
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_write_response_channel.sv
+../SVA-AXI4-FVIP/AXI4/src/amba_axi4_write_address_channel.sv
+
+# Bind file
+nervaxi_bind.sv
+
+# DUT
+nerv.sv
+nervaxi.sv

--- a/nervaxi.sv
+++ b/nervaxi.sv
@@ -587,8 +587,6 @@ typedef struct packed {
 } axi_ar_record;
 
 // Testbench helper providing a AXI4-Lite subordinate read interface
-//
-// Can test all allowed timings but does not handle multiple in-flight reads.
 module axi_lite_s_read_tester(
 	input clock,
 	input reset,
@@ -641,6 +639,7 @@ module axi_lite_s_read_tester(
 		.clock(clock),
 		.reset(reset),
 		.in_valid(read_txn_q),
+		.in_ready(),
 		.in_data({read_data, read_resp}),
 
 		.out_valid(axi_rvalid),
@@ -654,8 +653,6 @@ module axi_lite_s_read_tester(
 endmodule
 
 // Testbench helper providing a AXI4-Lite subordinate write interface
-//
-// Can test all allowed timings but does not handle multiple in-flight writes.
 module axi_lite_s_write_tester(
 	input clock,
 	input reset,
@@ -734,6 +731,7 @@ module axi_lite_s_write_tester(
 		.clock(clock),
 		.reset(reset),
 		.in_valid(write_txn_q),
+		.in_ready(),
 		.in_data(write_resp),
 
 		.out_valid(axi_bvalid),

--- a/nervaxi.sv
+++ b/nervaxi.sv
@@ -1,0 +1,449 @@
+/*
+ *  NERV -- Naive Educational RISC-V Processor
+ *
+ *  Copyright (C) 2023  Jannis Harder <jix@yosyshq.com> <me@jix.one>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+ module nerv_axi_lite_adapter (
+	input clock,
+	input reset,
+
+	// AXI4-Lite instruction memory interface
+	output            imem_axi_arvalid,
+	input             imem_axi_arready,
+	output reg [31:0] imem_axi_araddr,
+	output     [ 2:0] imem_axi_arprot,
+
+	input             imem_axi_rvalid,
+	output            imem_axi_rready,
+	input      [31:0] imem_axi_rdata,
+	input      [ 1:0] imem_axi_rresp,
+
+	// AXI4-Lite data memory interface
+	output reg        dmem_axi_awvalid,
+	input             dmem_axi_awready,
+	output reg [31:0] dmem_axi_awaddr,
+	output     [ 2:0] dmem_axi_awprot,
+
+	output reg        dmem_axi_wvalid,
+	input             dmem_axi_wready,
+	output reg [31:0] dmem_axi_wdata,
+	output reg [ 3:0] dmem_axi_wstrb,
+
+	input             dmem_axi_bvalid,
+	output            dmem_axi_bready,
+	input      [ 1:0] dmem_axi_bresp,
+
+	output reg        dmem_axi_arvalid,
+	input             dmem_axi_arready,
+	output reg [31:0] dmem_axi_araddr,
+	output     [ 2:0] dmem_axi_arprot,
+
+	input             dmem_axi_rvalid,
+	output            dmem_axi_rready,
+	input      [31:0] dmem_axi_rdata,
+	input      [ 1:0] dmem_axi_rresp,
+
+	// NERV memory interface
+	output            mem_stall,
+
+	input             stall,
+
+	input      [31:0] imem_addr,
+	output reg [31:0] imem_data,
+
+	input             dmem_valid,
+	input      [31:0] dmem_addr,
+	input      [ 3:0] dmem_wstrb,
+	input      [31:0] dmem_wdata,
+	output reg [31:0] dmem_rdata
+);
+
+	reg reset_q;
+
+	always @(posedge clock)
+		reset_q <= reset;
+
+	// === imem read ===
+
+	// AXI4 requries no valid signals in the first post-reset cycle, NERV
+	// starts an imem read in that cycle. We implement this by operating on
+	// imem_axi_arvalid_internal and imem_axi_arready_internal instead of the
+	// AXI signals. They are the same as the AXI signals except for the first
+	// post-reset cycle where imem_axi_arvalid is 0 even when
+	// imem_axi_arvalid_internal is 1 and imem_axi_arready_internal is 0 even
+	// when imem_axi_arready is 1.
+	reg imem_axi_arvalid_internal;
+	reg imem_axi_arvalid_internal_q;
+
+	wire imem_axi_arready_internal;
+	reg imem_axi_arready_internal_q;
+
+	assign imem_axi_arready_internal = imem_axi_arready && !reset_q;
+	assign imem_axi_arvalid = imem_axi_arvalid_internal && !reset_q;
+
+	reg [31:0] imem_axi_araddr_q;
+	reg [31:0] next_imem_data;
+
+	assign imem_axi_arprot = 3'b111;
+	assign imem_axi_rready = 1;
+
+	reg next_imem_rstall;
+	reg imem_rstall;
+
+	always @* begin
+		imem_axi_araddr = imem_axi_araddr_q;
+		imem_axi_arvalid_internal = imem_axi_arvalid_internal_q;
+		next_imem_rstall = imem_rstall;
+		next_imem_data = imem_data;
+
+		// reset valid when ready was active in the last cycle
+		if (imem_axi_arready_internal_q)
+			imem_axi_arvalid_internal = 0;
+
+		// perform an imem read after reset or when the imem addr changed
+		if (!next_imem_rstall && !imem_axi_arvalid_internal &&
+				(reset_q || imem_addr != imem_axi_araddr)) begin
+			imem_axi_araddr = imem_addr;
+			imem_axi_arvalid_internal = 1;
+			next_imem_rstall = 1;
+		end
+
+		// imem read response
+		next_imem_data = imem_data;
+		if (imem_axi_rready && imem_axi_rvalid) begin
+			// TODO handle imem_axi_rresp?
+			next_imem_data = imem_axi_rdata;
+			next_imem_rstall = 0;
+		end
+
+		// stop active reads when in reset
+		if (reset) begin
+			imem_axi_arvalid_internal = 0;
+			next_imem_rstall = 0;
+		end
+	end
+
+	always @(posedge clock) begin
+		imem_rstall <= next_imem_rstall;
+		imem_data <= next_imem_data;
+
+		imem_axi_arvalid_internal_q <= imem_axi_arvalid_internal;
+		imem_axi_arready_internal_q <= imem_axi_arready_internal;
+		imem_axi_araddr_q <= imem_axi_araddr;
+	end
+
+	// === dmem read ===
+	reg dmem_axi_arvalid_q;
+	reg dmem_axi_arready_q;
+
+	reg [31:0] dmem_axi_araddr_q;
+	reg [31:0] dmem_rdata_q;
+
+	assign dmem_axi_arprot = 3'b011;
+	assign dmem_axi_rready = 1;
+
+	reg next_dmem_rstall;
+	reg dmem_rstall;
+
+	always @* begin
+		dmem_axi_araddr = dmem_axi_araddr_q;
+		dmem_axi_arvalid = dmem_axi_arvalid_q;
+		next_dmem_rstall = dmem_rstall;
+
+		// reset valid when ready was active in the last cycle
+		if (dmem_axi_arready_q)
+			dmem_axi_arvalid = 0;
+
+		// perform a dmem read when requested by NERV
+		if (!next_dmem_rstall && !dmem_axi_arvalid &&
+				!stall && dmem_valid && !dmem_wstrb) begin
+			dmem_axi_araddr = dmem_addr;
+			dmem_axi_arvalid = 1;
+			next_dmem_rstall = 1;
+		end
+
+		// dmem read response
+		dmem_rdata = dmem_rdata_q;
+		if (dmem_axi_rready && dmem_axi_rvalid) begin
+			// TODO handle imem_axi_rresp?
+			dmem_rdata = dmem_axi_rdata;
+			next_dmem_rstall = 0;
+		end
+
+		// stop active reads when in reset
+		if (reset) begin
+			dmem_axi_arvalid = 0;
+			next_dmem_rstall = 0;
+		end
+	end
+
+	always @(posedge clock) begin
+		dmem_rstall <= next_dmem_rstall;
+		dmem_rdata_q <= dmem_rdata;
+
+		dmem_axi_arvalid_q <= dmem_axi_arvalid;
+		dmem_axi_arready_q <= dmem_axi_arready;
+		dmem_axi_araddr_q <= dmem_axi_araddr;
+	end
+
+	// === dmem write ===
+	reg dmem_axi_awvalid_q;
+	reg dmem_axi_awready_q;
+	reg [31:0] dmem_axi_awaddr_q;
+	reg dmem_axi_wvalid_q;
+	reg dmem_axi_wready_q;
+	reg [31:0] dmem_axi_wdata_q;
+	reg [3:0] dmem_axi_wstrb_q;
+
+	assign dmem_axi_awprot = 3'b011;
+	assign dmem_axi_bready = 1;
+
+	reg next_dmem_wstall;
+	reg dmem_wstall;
+
+	always @* begin
+		dmem_axi_awaddr = dmem_axi_awaddr_q;
+		dmem_axi_awvalid = dmem_axi_awvalid_q;
+		dmem_axi_wdata = dmem_axi_wdata_q;
+		dmem_axi_wstrb = dmem_axi_wstrb_q;
+		dmem_axi_wvalid = dmem_axi_wvalid_q;
+		next_dmem_wstall = dmem_wstall;
+
+		// reset valid when ready was active in the last cycle
+		if (dmem_axi_awready_q)
+			dmem_axi_awvalid = 0;
+
+		if (dmem_axi_wready_q)
+			dmem_axi_wvalid = 0;
+
+		// perform a dmem write when requested by NERV
+		if (!next_dmem_wstall && !dmem_axi_awvalid && !dmem_axi_wvalid &&
+				!stall && dmem_valid && dmem_wstrb) begin
+			dmem_axi_awaddr = dmem_addr;
+			dmem_axi_awvalid = 1;
+			dmem_axi_wdata = dmem_wdata;
+			dmem_axi_wstrb = dmem_wstrb;
+			dmem_axi_wvalid = 1;
+			next_dmem_wstall = 1;
+		end
+
+		// dmem write response
+		if (dmem_axi_bready && dmem_axi_bvalid) begin
+			// TODO handle imem_axi_bresp?
+			next_dmem_wstall = 0;
+		end
+
+		// stop active writes when in reset
+		if (reset || reset_q) begin
+			dmem_axi_awvalid = 0;
+			dmem_axi_wvalid = 0;
+			next_dmem_wstall = 0;
+		end
+	end
+
+	always @(posedge clock) begin
+		dmem_wstall <= next_dmem_wstall;
+
+		dmem_axi_awvalid_q <= dmem_axi_awvalid;
+		dmem_axi_awready_q <= dmem_axi_awready;
+		dmem_axi_awaddr_q <= dmem_axi_awaddr;
+		dmem_axi_wvalid_q <= dmem_axi_wvalid;
+		dmem_axi_wready_q <= dmem_axi_wready;
+		dmem_axi_wdata_q <= dmem_axi_wdata;
+		dmem_axi_wstrb_q <= dmem_axi_wstrb;
+	end
+
+	// === stall logic ===
+
+	assign mem_stall = !reset_q && (imem_rstall || dmem_wstall || dmem_rstall);
+
+endmodule
+
+module nerv_axi_lite #(
+	parameter [31:0] RESET_ADDR = 32'h 0000_0000,
+	parameter integer NUMREGS = 32
+) (
+	input clock,
+	input reset,
+	input stall,
+	output stalled,
+	output trap,
+
+`ifdef NERV_RVFI
+	output reg        rvfi_valid,
+	output reg [63:0] rvfi_order,
+	output reg [31:0] rvfi_insn,
+	output reg        rvfi_trap,
+	output reg        rvfi_halt,
+	output reg        rvfi_intr,
+	output reg [ 1:0] rvfi_mode,
+	output reg [ 1:0] rvfi_ixl,
+	output reg [ 4:0] rvfi_rs1_addr,
+	output reg [ 4:0] rvfi_rs2_addr,
+	output reg [31:0] rvfi_rs1_rdata,
+	output reg [31:0] rvfi_rs2_rdata,
+	output reg [ 4:0] rvfi_rd_addr,
+	output reg [31:0] rvfi_rd_wdata,
+	output reg [31:0] rvfi_pc_rdata,
+	output reg [31:0] rvfi_pc_wdata,
+	output reg [31:0] rvfi_mem_addr,
+	output reg [ 3:0] rvfi_mem_rmask,
+	output reg [ 3:0] rvfi_mem_wmask,
+	output reg [31:0] rvfi_mem_rdata,
+	output reg [31:0] rvfi_mem_wdata,
+`endif
+
+	// AXI4-Lite instruction memory interface
+	output            imem_axi_arvalid,
+	input             imem_axi_arready,
+	output     [31:0] imem_axi_araddr,
+	output     [ 2:0] imem_axi_arprot,
+
+	input             imem_axi_rvalid,
+	output            imem_axi_rready,
+	input      [31:0] imem_axi_rdata,
+	input      [ 1:0] imem_axi_rresp,
+
+	// AXI4-Lite data memory interface
+	output            dmem_axi_awvalid,
+	input             dmem_axi_awready,
+	output     [31:0] dmem_axi_awaddr,
+	output     [ 2:0] dmem_axi_awprot,
+
+	output            dmem_axi_wvalid,
+	input             dmem_axi_wready,
+	output     [31:0] dmem_axi_wdata,
+	output     [ 3:0] dmem_axi_wstrb,
+
+	input             dmem_axi_bvalid,
+	output            dmem_axi_bready,
+	input      [ 1:0] dmem_axi_bresp,
+
+	output            dmem_axi_arvalid,
+	input             dmem_axi_arready,
+	output     [31:0] dmem_axi_araddr,
+	output     [ 2:0] dmem_axi_arprot,
+
+	input             dmem_axi_rvalid,
+	output            dmem_axi_rready,
+	input      [31:0] dmem_axi_rdata,
+	input      [ 1:0] dmem_axi_rresp
+);
+
+	wire mem_stall;
+	assign stalled = stall || mem_stall;
+
+	wire [31:0] imem_addr;
+	wire [31:0] imem_data;
+
+	// the other is data memory
+	wire dmem_valid;
+	wire [31:0] dmem_addr;
+	wire [3:0] dmem_wstrb;
+	wire [31:0] dmem_wdata;
+	wire [31:0] dmem_rdata;
+
+	nerv #(.RESET_ADDR(RESET_ADDR), .NUMREGS(NUMREGS)) nerv (
+		.clock(clock),
+		.reset(reset),
+		.stall(stalled),
+		.trap(trap),
+
+`ifdef NERV_RVFI
+		.rvfi_valid(rvfi_valid),
+		.rvfi_order(rvfi_order),
+		.rvfi_insn(rvfi_insn),
+		.rvfi_trap(rvfi_trap),
+		.rvfi_halt(rvfi_halt),
+		.rvfi_intr(rvfi_intr),
+		.rvfi_mode(rvfi_mode),
+		.rvfi_ixl(rvfi_ixl),
+		.rvfi_rs1_addr(rvfi_rs1_addr),
+		.rvfi_rs2_addr(rvfi_rs2_addr),
+		.rvfi_rs1_rdata(rvfi_rs1_rdata),
+		.rvfi_rs2_rdata(rvfi_rs2_rdata),
+		.rvfi_rd_addr(rvfi_rd_addr),
+		.rvfi_rd_wdata(rvfi_rd_wdata),
+		.rvfi_pc_rdata(rvfi_pc_rdata),
+		.rvfi_pc_wdata(rvfi_pc_wdata),
+		.rvfi_mem_addr(rvfi_mem_addr),
+		.rvfi_mem_rmask(rvfi_mem_rmask),
+		.rvfi_mem_wmask(rvfi_mem_wmask),
+		.rvfi_mem_rdata(rvfi_mem_rdata),
+		.rvfi_mem_wdata(rvfi_mem_wdata),
+`endif
+
+		.imem_addr(imem_addr),
+		.imem_data(imem_data),
+		.dmem_valid(dmem_valid),
+		.dmem_addr(dmem_addr),
+		.dmem_wstrb(dmem_wstrb),
+		.dmem_wdata(dmem_wdata),
+		.dmem_rdata(dmem_rdata)
+	);
+
+	nerv_axi_lite_adapter nerv_axi_lite_adapter (
+		.clock(clock),
+		.reset(reset),
+
+		.imem_axi_arvalid(imem_axi_arvalid),
+		.imem_axi_arready(imem_axi_arready),
+		.imem_axi_araddr(imem_axi_araddr),
+		.imem_axi_arprot(imem_axi_arprot),
+
+		.imem_axi_rvalid(imem_axi_rvalid),
+		.imem_axi_rready(imem_axi_rready),
+		.imem_axi_rdata(imem_axi_rdata),
+		.imem_axi_rresp(imem_axi_rresp),
+
+		.dmem_axi_awvalid(dmem_axi_awvalid),
+		.dmem_axi_awready(dmem_axi_awready),
+		.dmem_axi_awaddr(dmem_axi_awaddr),
+		.dmem_axi_awprot(dmem_axi_awprot),
+
+		.dmem_axi_wvalid(dmem_axi_wvalid),
+		.dmem_axi_wready(dmem_axi_wready),
+		.dmem_axi_wdata(dmem_axi_wdata),
+		.dmem_axi_wstrb(dmem_axi_wstrb),
+
+		.dmem_axi_bvalid(dmem_axi_bvalid),
+		.dmem_axi_bready(dmem_axi_bready),
+		.dmem_axi_bresp(dmem_axi_bresp),
+
+		.dmem_axi_arvalid(dmem_axi_arvalid),
+		.dmem_axi_arready(dmem_axi_arready),
+		.dmem_axi_araddr(dmem_axi_araddr),
+		.dmem_axi_arprot(dmem_axi_arprot),
+
+		.dmem_axi_rvalid(dmem_axi_rvalid),
+		.dmem_axi_rready(dmem_axi_rready),
+		.dmem_axi_rdata(dmem_axi_rdata),
+		.dmem_axi_rresp(dmem_axi_rresp),
+
+		.imem_addr(imem_addr),
+		.imem_data(imem_data),
+		.dmem_valid(dmem_valid),
+		.dmem_addr(dmem_addr),
+		.dmem_wstrb(dmem_wstrb),
+		.dmem_wdata(dmem_wdata),
+		.dmem_rdata(dmem_rdata),
+
+		.stall(stalled),
+		.mem_stall(mem_stall)
+	);
+
+endmodule

--- a/nervaxi_bind.sv
+++ b/nervaxi_bind.sv
@@ -1,0 +1,116 @@
+module reset_assumptions(input reset);
+	always @* if ($initstate) assume(reset);
+endmodule
+
+bind nerv_axi_lite reset_assumptions reset_assumptions(.reset(reset));
+
+`ifdef NERVAXI_CHECK_DMEM
+bind nerv_axi_lite amba_axi4_protocol_checker
+  #(.cfg('{ID_WIDTH:          4,
+	   ADDRESS_WIDTH:     32,
+	   DATA_WIDTH:        32,
+	   AWUSER_WIDTH:      32,
+	   WUSER_WIDTH:       32,
+	   BUSER_WIDTH:       32,
+	   ARUSER_WIDTH:      32,
+	   RUSER_WIDTH:       32,
+	   MAX_WR_BURSTS:     1,
+	   MAX_RD_BURSTS:     1,
+	   MAX_WR_LENGTH:     1,
+	   MAX_RD_LENGTH:     1,
+	   MAXWAIT:           16,
+	   VERIFY_AGENT_TYPE: amba_axi4_protocol_checker_pkg::SOURCE,
+	   PROTOCOL_TYPE:     amba_axi4_protocol_checker_pkg::AXI4LITE,
+	   INTERFACE_REQS:    1,
+	   ENABLE_COVER:      1,
+	   ENABLE_XPROP:      0,
+	   ARM_RECOMMENDED:   1,
+	   CHECK_PARAMETERS:  1,
+	   OPTIONAL_WSTRB:    0,
+	   FULL_WR_STRB:      1,
+	   OPTIONAL_RESET:    0,
+	   EXCLUSIVE_ACCESS:  1,
+	   OPTIONAL_LP:       0})) dmem_axi4_checker_source
+  (.ACLK(clock),
+   .ARESETn(!reset),
+
+   .AWVALID(dmem_axi_awvalid),
+   .AWREADY(dmem_axi_awready),
+   .AWADDR(dmem_axi_awaddr),
+   .AWPROT(dmem_axi_awprot),
+
+   .WVALID(dmem_axi_wvalid),
+   .WREADY(dmem_axi_wready),
+   .WDATA(dmem_axi_wdata),
+   .WSTRB(dmem_axi_wstrb),
+
+   .BVALID(dmem_axi_bvalid),
+   .BREADY(dmem_axi_bready),
+   .BRESP(dmem_axi_bresp),
+
+   .ARVALID(dmem_axi_arvalid),
+   .ARREADY(dmem_axi_arready),
+   .ARADDR(dmem_axi_araddr),
+   .ARPROT(dmem_axi_arprot),
+
+   .RVALID(dmem_axi_rvalid),
+   .RREADY(dmem_axi_rready),
+   .RDATA(dmem_axi_rdata),
+   .RRESP(dmem_axi_rresp));
+`endif
+
+
+`ifdef NERVAXI_CHECK_IMEM
+bind nerv_axi_lite amba_axi4_protocol_checker
+  #(.cfg('{ID_WIDTH:          4,
+	   ADDRESS_WIDTH:     32,
+	   DATA_WIDTH:        32,
+	   AWUSER_WIDTH:      32,
+	   WUSER_WIDTH:       32,
+	   BUSER_WIDTH:       32,
+	   ARUSER_WIDTH:      32,
+	   RUSER_WIDTH:       32,
+	   MAX_WR_BURSTS:     1,
+	   MAX_RD_BURSTS:     1,
+	   MAX_WR_LENGTH:     1,
+	   MAX_RD_LENGTH:     1,
+	   MAXWAIT:           16,
+	   VERIFY_AGENT_TYPE: amba_axi4_protocol_checker_pkg::SOURCE,
+	   PROTOCOL_TYPE:     amba_axi4_protocol_checker_pkg::AXI4LITE,
+	   INTERFACE_REQS:    1,
+	   ENABLE_COVER:      1,
+	   ENABLE_XPROP:      0,
+	   ARM_RECOMMENDED:   1,
+	   CHECK_PARAMETERS:  1,
+	   OPTIONAL_WSTRB:    1,
+	   FULL_WR_STRB:      1,
+	   OPTIONAL_RESET:    0,
+	   EXCLUSIVE_ACCESS:  1,
+	   OPTIONAL_LP:       0})) imem_axi4_checker_source
+  (.ACLK(clock),
+   .ARESETn(!reset),
+
+   .AWVALID(1'b0),
+   // .AWREADY(),
+   .AWADDR(32'bx),
+   .AWPROT(3'bx),
+
+   .WVALID(1'b0),
+   // .WREADY(),
+   .WDATA(32'bx),
+   .WSTRB(4'bx),
+
+   // .BVALID(),
+   .BREADY(1'b0),
+   // .BRESP(),
+
+   .ARVALID(imem_axi_arvalid),
+   .ARREADY(imem_axi_arready),
+   .ARADDR(imem_axi_araddr),
+   .ARPROT(imem_axi_arprot),
+
+   .RVALID(imem_axi_rvalid),
+   .RREADY(imem_axi_rready),
+   .RDATA(imem_axi_rdata),
+   .RRESP(imem_axi_rresp));
+`endif

--- a/testbench.sv
+++ b/testbench.sv
@@ -55,11 +55,17 @@ always @(posedge clock) begin
 	end
 end
 
-`ifdef STALL
-always @(posedge clock) begin
-	stall <= $random;
+integer stall_seed;
+
+initial begin
+    if (!$value$plusargs("stall=%d", stall_seed))
+        stall_seed = 0;
 end
-`endif
+
+always @(posedge clock) begin
+    if (stall_seed != 0)
+        stall <= $random(stall_seed);
+end
 
 always @(posedge clock) begin
 	if (imem_addr >= (1<<MEM_ADDR_WIDTH)) begin

--- a/testbench_axi.gtkw
+++ b/testbench_axi.gtkw
@@ -1,0 +1,223 @@
+[*]
+[*] GTKWave Analyzer v3.3.107 (w)1999-2020 BSI
+[*] Tue Oct 20 19:25:31 2020
+[*]
+[dumpfile] "testbench.vcd"
+[dumpfile_mtime] "Tue Oct 20 19:24:49 2020"
+[dumpfile_size] 76428
+[savefile] "testbench.gtkw"
+[timestart] 305
+[size] 1397 995
+[pos] -1 -1
+*-6.000000 497 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] testbench.
+[sst_width] 240
+[signals_width] 174
+[sst_expanded] 1
+[sst_vpaned_height] 289
+@28
+testbench.dut.nerv.clock
+testbench.dut.nerv.reset
+testbench.dut.nerv.stall
+testbench.dut.nerv.trap
+@200
+-
+@22
+testbench.dut.nerv.imem_addr[31:0]
+testbench.dut.nerv.imem_data[31:0]
+@200
+-
+@28
+testbench.dut.nerv.dmem_valid
+@22
+testbench.dut.nerv.dmem_addr[31:0]
+testbench.dut.nerv.dmem_wstrb[3:0]
+testbench.dut.nerv.dmem_wdata[31:0]
+testbench.dut.nerv.dmem_rdata[31:0]
+@200
+-
+@22
+testbench.dut.nerv.pc[31:0]
+testbench.dut.nerv.insn[31:0]
+@28
+testbench.dut.nerv.illinsn
+@c00200
+-insn_decoded
+@22
+testbench.dut.nerv.insn_funct7[6:0]
+testbench.dut.nerv.insn_rs2[4:0]
+testbench.dut.nerv.insn_rs1[4:0]
+@28
+testbench.dut.nerv.insn_funct3[2:0]
+@22
+testbench.dut.nerv.insn_rd[4:0]
+testbench.dut.nerv.insn_opcode[6:0]
+@200
+-
+@22
+testbench.dut.nerv.imm_b_sext[31:0]
+testbench.dut.nerv.imm_i_sext[31:0]
+testbench.dut.nerv.imm_j_sext[31:0]
+testbench.dut.nerv.imm_s_sext[31:0]
+@1401200
+-insn_decoded
+@22
+testbench.dut.nerv.rs1_value[31:0]
+testbench.dut.nerv.rs2_value[31:0]
+@28
+testbench.dut.nerv.next_wr
+@22
+testbench.dut.nerv.next_rd[31:0]
+@c00201
+-registers
+@22
+testbench.dut.nerv.dbg_reg_x0[31:0]
+testbench.dut.nerv.dbg_reg_x1[31:0]
+testbench.dut.nerv.dbg_reg_x2[31:0]
+testbench.dut.nerv.dbg_reg_x3[31:0]
+testbench.dut.nerv.dbg_reg_x4[31:0]
+testbench.dut.nerv.dbg_reg_x5[31:0]
+testbench.dut.nerv.dbg_reg_x6[31:0]
+testbench.dut.nerv.dbg_reg_x7[31:0]
+testbench.dut.nerv.dbg_reg_x8[31:0]
+testbench.dut.nerv.dbg_reg_x9[31:0]
+testbench.dut.nerv.dbg_reg_x10[31:0]
+testbench.dut.nerv.dbg_reg_x11[31:0]
+testbench.dut.nerv.dbg_reg_x12[31:0]
+testbench.dut.nerv.dbg_reg_x13[31:0]
+testbench.dut.nerv.dbg_reg_x14[31:0]
+testbench.dut.nerv.dbg_reg_x15[31:0]
+testbench.dut.nerv.dbg_reg_x16[31:0]
+testbench.dut.nerv.dbg_reg_x17[31:0]
+testbench.dut.nerv.dbg_reg_x18[31:0]
+testbench.dut.nerv.dbg_reg_x19[31:0]
+testbench.dut.nerv.dbg_reg_x20[31:0]
+testbench.dut.nerv.dbg_reg_x21[31:0]
+testbench.dut.nerv.dbg_reg_x22[31:0]
+testbench.dut.nerv.dbg_reg_x23[31:0]
+testbench.dut.nerv.dbg_reg_x24[31:0]
+testbench.dut.nerv.dbg_reg_x25[31:0]
+testbench.dut.nerv.dbg_reg_x26[31:0]
+testbench.dut.nerv.dbg_reg_x27[31:0]
+testbench.dut.nerv.dbg_reg_x28[31:0]
+testbench.dut.nerv.dbg_reg_x29[31:0]
+testbench.dut.nerv.dbg_reg_x30[31:0]
+testbench.dut.nerv.dbg_reg_x31[31:0]
+@1401201
+-registers
+@200
+-
+@28
+testbench.dut.nerv.mem_rd_enable
+@22
+testbench.dut.nerv.mem_rd_addr[31:0]
+testbench.dut.nerv.mem_rd_func[4:0]
+testbench.dut.nerv.mem_rd_reg[4:0]
+@200
+-
+@28
+testbench.dut.nerv.mem_rd_enable_q
+@22
+testbench.dut.nerv.mem_rd_func_q[4:0]
+testbench.dut.nerv.mem_rd_reg_q[4:0]
+testbench.dut.nerv.mem_rdata[31:0]
+@200
+-
+@28
+testbench.dut.nerv.mem_wr_enable
+@22
+testbench.dut.nerv.mem_wr_addr[31:0]
+testbench.dut.nerv.mem_wr_data[31:0]
+testbench.dut.nerv.mem_wr_strb[3:0]
+@c00201
+-AXI imem reads
+@29
+testbench.test_imem_read.read_txn
+@23
+testbench.test_imem_read.read_addr[31:0]
+@29
+testbench.test_imem_read.read_prot[2:0]
+@23
+testbench.test_imem_read.read_data[31:0]
+@29
+testbench.test_imem_read.read_resp[1:0]
+@c00201
+-AXI bus
+@22
+testbench.test_imem_read.axi_araddr[31:0]
+@28
+testbench.test_imem_read.axi_arprot[2:0]
+testbench.test_imem_read.axi_arready
+testbench.test_imem_read.axi_arvalid
+@22
+testbench.test_imem_read.axi_rdata[31:0]
+@28
+testbench.test_imem_read.axi_rready
+testbench.test_imem_read.axi_rresp[1:0]
+testbench.test_imem_read.axi_rvalid
+@1401201
+-AXI bus
+-AXI imem reads
+@c00200
+-AXI dmem reads
+@28
+testbench.test_dmem_read.read_txn
+@22
+testbench.test_dmem_read.read_addr[31:0]
+@28
+testbench.test_dmem_read.read_prot[2:0]
+@22
+testbench.test_dmem_read.read_data[31:0]
+@28
+testbench.test_dmem_read.read_resp[1:0]
+@c00200
+-AXI bus
+@22
+testbench.test_dmem_read.axi_araddr[31:0]
+@28
+testbench.test_dmem_read.axi_arprot[2:0]
+testbench.test_dmem_read.axi_arready
+testbench.test_dmem_read.axi_arvalid
+@22
+testbench.test_dmem_read.axi_rdata[31:0]
+@28
+testbench.test_dmem_read.axi_rready
+testbench.test_dmem_read.axi_rresp[1:0]
+testbench.test_dmem_read.axi_rvalid
+@1401200
+-AXI bus
+-AXI dmem reads
+@c00200
+-AXI dmem writes
+@28
+testbench.test_dmem_write.write_txn
+@22
+testbench.test_dmem_write.write_addr[31:0]
+testbench.test_dmem_write.write_data[31:0]
+@28
+testbench.test_dmem_write.write_prot[2:0]
+testbench.test_dmem_write.write_resp[1:0]
+@c00200
+-AXI bus
+@22
+testbench.test_dmem_write.axi_awaddr[31:0]
+@28
+testbench.test_dmem_write.axi_awprot[2:0]
+testbench.test_dmem_write.axi_awready
+testbench.test_dmem_write.axi_awvalid
+testbench.test_dmem_write.axi_bready
+testbench.test_dmem_write.axi_bresp[1:0]
+testbench.test_dmem_write.axi_bvalid
+@22
+testbench.test_dmem_write.axi_wdata[31:0]
+@28
+testbench.test_dmem_write.axi_wready
+@22
+testbench.test_dmem_write.axi_wstrb[3:0]
+@28
+testbench.test_dmem_write.axi_wvalid
+@1401200
+-AXI bus
+-AXI dmem writes
+[pattern_trace] 1
+[pattern_trace] 0

--- a/testbench_axi.sv
+++ b/testbench_axi.sv
@@ -1,0 +1,302 @@
+/*
+ *  NERV -- Naive Educational RISC-V Processor
+ *
+ *  Copyright (C) 2020  N. Engelhardt <nak@yosyshq.com>
+ *  Copyright (C) 2023  Jannis Harder <jix@yosyshq.com> <me@jix.one>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+module testbench;
+
+localparam MEM_ADDR_WIDTH = 16;
+localparam TIMEOUT = (1<<10);
+
+
+reg clock;
+reg reset = 1'b1;
+wire trap;
+
+always #5 clock = clock === 1'b0;
+always @(posedge clock) reset <= 0;
+
+reg [7:0] mem [0:(1<<MEM_ADDR_WIDTH)-1];
+
+initial begin
+	$readmemh("firmware.hex", mem);
+	if ($test$plusargs("vcd")) begin
+		$dumpfile("testbench_axi.vcd");
+		$dumpvars(0, testbench);
+	end
+end
+
+integer stall_seed;
+
+initial begin
+	if (!$value$plusargs("stall=%d", stall_seed))
+		stall_seed = 0;
+end
+
+reg stall = 1'b0;
+
+always @(posedge clock) begin
+	if (stall_seed != 0 && !reset)
+		stall <= $random(stall_seed);
+end
+
+// AXI4-Lite signals
+
+wire        imem_axi_arvalid;
+wire        imem_axi_arready;
+wire [31:0] imem_axi_araddr;
+wire [ 2:0] imem_axi_arprot;
+
+wire        imem_axi_rvalid;
+wire        imem_axi_rready;
+wire [31:0] imem_axi_rdata;
+wire [ 1:0] imem_axi_rresp;
+
+wire        dmem_axi_arvalid;
+wire        dmem_axi_arready;
+wire [31:0] dmem_axi_araddr;
+wire [ 2:0] dmem_axi_arprot;
+
+wire        dmem_axi_rvalid;
+wire        dmem_axi_rready;
+wire [31:0] dmem_axi_rdata;
+wire [ 1:0] dmem_axi_rresp;
+
+wire        dmem_axi_awvalid;
+wire        dmem_axi_awready;
+wire [31:0] dmem_axi_awaddr;
+wire [ 2:0] dmem_axi_awprot;
+
+wire        dmem_axi_wvalid;
+wire        dmem_axi_wready;
+wire [31:0] dmem_axi_wdata;
+wire [ 3:0] dmem_axi_wstrb;
+
+wire        dmem_axi_bvalid;
+wire        dmem_axi_bready;
+wire [ 1:0] dmem_axi_bresp;
+
+// NERV core with an AXI4-Lite interface
+
+nerv_axi_lite dut (
+	.clock(clock),
+	.reset(reset),
+	.stall(stall),
+	.trap(trap),
+
+	.imem_axi_arvalid(imem_axi_arvalid),
+	.imem_axi_arready(imem_axi_arready),
+	.imem_axi_araddr(imem_axi_araddr),
+	.imem_axi_arprot(imem_axi_arprot),
+	.imem_axi_rvalid(imem_axi_rvalid),
+	.imem_axi_rready(imem_axi_rready),
+	.imem_axi_rdata(imem_axi_rdata),
+	.imem_axi_rresp(imem_axi_rresp),
+
+	.dmem_axi_arvalid(dmem_axi_arvalid),
+	.dmem_axi_arready(dmem_axi_arready),
+	.dmem_axi_araddr(dmem_axi_araddr),
+	.dmem_axi_arprot(dmem_axi_arprot),
+	.dmem_axi_rvalid(dmem_axi_rvalid),
+	.dmem_axi_rready(dmem_axi_rready),
+	.dmem_axi_rdata(dmem_axi_rdata),
+	.dmem_axi_rresp(dmem_axi_rresp),
+
+	.dmem_axi_awvalid(dmem_axi_awvalid),
+	.dmem_axi_awready(dmem_axi_awready),
+	.dmem_axi_awaddr(dmem_axi_awaddr),
+	.dmem_axi_awprot(dmem_axi_awprot),
+	.dmem_axi_wvalid(dmem_axi_wvalid),
+	.dmem_axi_wready(dmem_axi_wready),
+	.dmem_axi_wdata(dmem_axi_wdata),
+	.dmem_axi_wstrb(dmem_axi_wstrb),
+	.dmem_axi_bvalid(dmem_axi_bvalid),
+	.dmem_axi_bready(dmem_axi_bready),
+	.dmem_axi_bresp(dmem_axi_bresp)
+);
+
+// Testbench AXI4 memory and IO device
+
+reg [ 1:0] imem_read_stall = 2'b00;
+
+wire        imem_read_txn;
+wire [31:0] imem_read_addr;
+wire [ 2:0] imem_read_prot;
+reg  [31:0] imem_read_data;
+reg  [ 1:0] imem_read_resp;
+
+axi_lite_s_read_tester test_imem_read (
+	.clock(clock),
+	.reset(reset),
+
+	.axi_arvalid(imem_axi_arvalid),
+	.axi_arready(imem_axi_arready),
+	.axi_araddr(imem_axi_araddr),
+	.axi_arprot(imem_axi_arprot),
+	.axi_rvalid(imem_axi_rvalid),
+	.axi_rready(imem_axi_rready),
+	.axi_rdata(imem_axi_rdata),
+	.axi_rresp(imem_axi_rresp),
+
+	.stall(imem_read_stall),
+
+	.read_txn(imem_read_txn),
+	.read_addr(imem_read_addr),
+	.read_prot(imem_read_prot),
+	.read_data(imem_read_data),
+	.read_resp(imem_read_resp)
+);
+
+reg [ 1:0] dmem_read_stall = 2'b00;
+reg [ 2:0] dmem_write_stall = 3'b000;
+
+wire        dmem_read_txn;
+wire [31:0] dmem_read_addr;
+wire [ 2:0] dmem_read_prot;
+reg  [31:0] dmem_read_data;
+reg  [ 1:0] dmem_read_resp;
+
+
+wire        dmem_write_txn;
+wire [31:0] dmem_write_addr;
+wire [ 2:0] dmem_write_prot;
+wire [31:0] dmem_write_data;
+wire [ 3:0] dmem_write_wstrb;
+reg  [ 1:0] dmem_write_resp;
+
+axi_lite_s_read_tester test_dmem_read (
+	.clock(clock),
+	.reset(reset),
+
+	.axi_arvalid(dmem_axi_arvalid),
+	.axi_arready(dmem_axi_arready),
+	.axi_araddr(dmem_axi_araddr),
+	.axi_arprot(dmem_axi_arprot),
+	.axi_rvalid(dmem_axi_rvalid),
+	.axi_rready(dmem_axi_rready),
+	.axi_rdata(dmem_axi_rdata),
+	.axi_rresp(dmem_axi_rresp),
+
+	.stall(dmem_read_stall),
+
+	.read_txn(dmem_read_txn),
+	.read_addr(dmem_read_addr),
+	.read_prot(dmem_read_prot),
+	.read_data(dmem_read_data),
+	.read_resp(dmem_read_resp)
+);
+
+axi_lite_s_write_tester test_dmem_write (
+	.clock(clock),
+	.reset(reset),
+
+	.axi_awvalid(dmem_axi_awvalid),
+	.axi_awready(dmem_axi_awready),
+	.axi_awaddr(dmem_axi_awaddr),
+	.axi_awprot(dmem_axi_awprot),
+	.axi_wvalid(dmem_axi_wvalid),
+	.axi_wready(dmem_axi_wready),
+	.axi_wdata(dmem_axi_wdata),
+	.axi_wstrb(dmem_axi_wstrb),
+	.axi_bvalid(dmem_axi_bvalid),
+	.axi_bready(dmem_axi_bready),
+	.axi_bresp(dmem_axi_bresp),
+
+	.stall(dmem_write_stall),
+
+	.write_txn(dmem_write_txn),
+	.write_addr(dmem_write_addr),
+	.write_prot(dmem_write_prot),
+	.write_data(dmem_write_data),
+	.write_wstrb(dmem_write_wstrb),
+	.write_resp(dmem_write_resp)
+);
+
+localparam [1:0] AXI_RESP_OKAY = 2'b00;
+localparam [1:0] AXI_RESP_SLVERR = 2'b10;
+localparam [1:0] AXI_RESP_DECERR = 2'b11;
+
+always @(posedge clock) begin : axi_testbench
+	integer i;
+
+	imem_read_data <= 'x;
+	imem_read_resp <= imem_read_txn ? AXI_RESP_DECERR : 'x;
+	dmem_read_data <= 'x;
+	dmem_read_resp <= dmem_read_txn ? AXI_RESP_DECERR : 'x;
+	dmem_write_resp <= dmem_write_txn ? AXI_RESP_DECERR : 'x;
+
+	if (stall_seed != 0) begin
+		imem_read_stall <= $random(stall_seed);
+		dmem_read_stall <= $random(stall_seed);
+		dmem_write_stall <= $random(stall_seed);
+	end
+
+	if (imem_read_txn) begin
+		if (imem_read_addr < (1<<MEM_ADDR_WIDTH)) begin
+			imem_read_resp <= AXI_RESP_OKAY;
+			for (i = 0; i < 4; i++)
+				imem_read_data[8 * i +: 8] <= mem[{imem_read_addr[MEM_ADDR_WIDTH-1:2], i[1:0]}];
+		end else begin
+			$display("Memory access out of range: imem_read_addr = 0x%08x", imem_read_addr);
+		end
+	end
+
+	if (dmem_read_txn) begin
+		if (dmem_read_addr < (1<<MEM_ADDR_WIDTH)) begin
+			dmem_read_resp <= AXI_RESP_OKAY;
+			for (i = 0; i < 4; i++)
+				dmem_read_data[8 * i +: 8] <= mem[{dmem_read_addr[MEM_ADDR_WIDTH-1:2], i[1:0]}];
+		end else if (dmem_write_addr == 32'h 02000000) begin
+			dmem_write_resp <= AXI_RESP_SLVERR;
+			$display("Read of write-only addr: dmem_read_addr = 0x%08x", dmem_read_addr);
+		end else begin
+			$display("Memory access out of range: dmem_read_addr = 0x%08x", dmem_read_addr);
+		end
+	end
+
+	if (dmem_write_txn) begin
+		if (dmem_write_addr < (1<<MEM_ADDR_WIDTH)) begin
+			dmem_write_resp <= AXI_RESP_OKAY;
+			for (i = 0; i < 4; i++)
+				if (dmem_write_wstrb[i])
+					mem[{dmem_write_addr[MEM_ADDR_WIDTH-1:2], i[1:0]}] <= dmem_write_data[8 * i +: 8];
+		end else if (dmem_write_addr == 32'h 02000000) begin
+			dmem_write_resp <= AXI_RESP_OKAY;
+			$write("%c", dmem_write_data[7:0]);
+`ifndef VERILATOR
+			$fflush();
+`endif
+		end else begin
+			$display("Memory access out of range: dmem_write_addr = 0x%08x", dmem_write_addr);
+		end
+	end
+end
+
+reg [31:0] cycles = 0;
+
+always @(posedge clock) begin
+	cycles <= cycles + 32'h1;
+	if (trap || (cycles >= TIMEOUT)) begin
+		$display("Simulated %0d cycles", cycles);
+		$finish;
+	end
+end
+
+
+
+endmodule


### PR DESCRIPTION
Current status

- [x] Working AXI4-Lite adapter (separate interface for instruction and data memory)
- [x] Automated check for illegal combinatorial paths in the adapter's AXI4-Lite interface
- [x] SVA-AXI4-FVIP testbench for the adapter (passes in prove mode with abc pdr)
- [x] Simulator testbench (need to clean up and add what I used for testing)
- [ ] Formal checks for RVFI vs AXI-Lite
- [ ] Full AXI support, including caching 

Needs YosysHQ-GmbH/SVA-AXI4-FVIP#5 for the SVA-AXI4-FVIP testbench to pass