### PR TITLE
Update for CSRs as defined in version 1.12/20211203

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ check: checks
 show:
 	gtkwave testbench.vcd testbench.gtkw >> gtkwave.log 2>&1 &
 
+trace:
+	gtkwave cexdata/checks_$(TRACE_CHECK)_ch0.vcd trace.gtkw >> gtkwave.log 2>&1 &
+
 clean:
 	rm -rf firmware.elf firmware.hex testbench testbench.vcd gtkwave.log
 	rm -rf disasm.o disasm.s checks/ cexdata/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TOOLCHAIN_PREFIX?=riscv64-unknown-elf-
 test: firmware.hex testbench
 	vvp -N testbench +vcd
 
-firmware.elf: firmware.s firmware.c
+firmware.elf: firmware.s vectors.s firmware.c
 	$(TOOLCHAIN_PREFIX)gcc -march=rv32i -mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $^
 
 firmware.hex: firmware.elf

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,13 @@
 
 TOOLCHAIN_PREFIX?=riscv64-unknown-elf-
 
+RISCV_ARCH?=rv32i$(shell $(TOOLCHAIN_PREFIX)as -march=rv32i_zicsr --dump-config 2>/dev/null && echo _zicsr)
+
 test: firmware.hex testbench
 	vvp -N testbench +vcd
 
 firmware.elf: firmware.s vectors.s firmware.c
-	$(TOOLCHAIN_PREFIX)gcc -march=rv32i -mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $^
+	$(TOOLCHAIN_PREFIX)gcc -march=$(RISCV_ARCH) -mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $^
 
 firmware.hex: firmware.elf
 	$(TOOLCHAIN_PREFIX)objcopy -O verilog $< $@

--- a/checks.cfg
+++ b/checks.cfg
@@ -16,6 +16,7 @@
 
 [options]
 isa rv32i
+nbus 2
 
 [depth]
 insn            10
@@ -26,6 +27,8 @@ unique     1  5 10
 causal     5    10
 cover      1    10
 csrw            10
+bus_imem   1    10
+bus_dmem   1    10
 
 [sort]
 reg_ch0

--- a/checks.cfg
+++ b/checks.cfg
@@ -27,8 +27,11 @@ unique     1  5 10
 causal     5    10
 cover      1    10
 csrw            10
-bus_imem   1    10
-bus_dmem   1    10
+
+bus_imem            1    10
+bus_imem_fault      1    10
+bus_dmem            1    10
+bus_dmem_fault      1    10
 
 [sort]
 reg_ch0
@@ -36,11 +39,15 @@ reg_ch0
 [csrs]
 mcycle
 minstret
+mcause
 
 [defines]
 `define YOSYS // Hotfix for older Tabby CAD Releases
 `define NERV_RVFI
+`define NERV_FAULT
 `define RISCV_FORMAL_ALIGNED_MEM
+`define RISCV_FORMAL_MEM_FAULT
+
 
 [defines liveness]
 `define NERV_FAIRNESS

--- a/checks.cfg
+++ b/checks.cfg
@@ -26,20 +26,28 @@ pc_bwd     5    10
 unique     1  5 10
 causal     5    10
 cover      1    10
+ill             10
 csrw            10
 
 bus_imem            1    10
 bus_imem_fault      1    10
 bus_dmem            1    10
 bus_dmem_fault      1    10
+csrc_zero  1    5
+csrc_any   1    5
+csrc_inc   1    5
 
 [sort]
 reg_ch0
 
 [csrs]
-mcycle
-minstret
 mcause
+mcycle          inc
+mscratch        any
+minstret        inc
+misa            zero
+mstatus
+mvendorid
 
 [defines]
 `define YOSYS // Hotfix for older Tabby CAD Releases
@@ -58,3 +66,4 @@ mcause
 
 [cover]
 always @* if (!reset) cover (channel[0].cnt_insns == 2);
+always @* if (!reset) cover (rvfi_csr_mstatus_rdata[3] != 0 && rvfi_valid == 1);

--- a/checks.cfg
+++ b/checks.cfg
@@ -39,19 +39,20 @@ csrc_zero  1    5
 csrc_any   1    5
 csrc_inc   1    5
 csrc_const 1    5
+csrc_upcnt 1    10
 
 [sort]
 reg_ch0
 
 [csrs]
 mcause
-mcycle          inc
+mcycle          inc upcnt
 mscratch        any
-minstret        inc
+minstret        upcnt
 misa            zero const="32'h 0"
 mstatus
 mvendorid       const
-mhpmcounter3	inc
+mhpmcounter3	upcnt_hpm=3
 mhpmevent3
 
 [custom_csrs]
@@ -80,4 +81,5 @@ f11     m       w
 [cover]
 always @* if (!reset) cover (channel[0].cnt_insns == 2);
 always @* if (!reset) cover (rvfi_csr_mstatus_rdata[3] != 0 && rvfi_valid == 1);
-always @* if (!reset) cover (rvfi_csr_mhpmevent3_rdata && rvfi_valid == 1);
+always @* if (!reset) cover (rvfi_csr_mhpmevent3_rdata == 3 && rvfi_csr_mhpmcounter3_rdata > 0 && rvfi_valid == 1);
+

--- a/checks.cfg
+++ b/checks.cfg
@@ -49,6 +49,10 @@ misa            zero
 mstatus
 mvendorid
 
+[custom_csrs]
+fc0     m       custom_ro
+bc0     mu      custom          any
+
 [defines]
 `define YOSYS // Hotfix for older Tabby CAD Releases
 `define NERV_RVFI

--- a/checks.cfg
+++ b/checks.cfg
@@ -17,6 +17,7 @@
 [options]
 isa rv32i
 nbus 2
+csr_spec 1.12
 
 [depth]
 insn            10

--- a/checks.cfg
+++ b/checks.cfg
@@ -51,6 +51,8 @@ minstret        inc
 misa            zero const="32'h 0"
 mstatus
 mvendorid       const
+mhpmcounter3	inc
+mhpmevent3
 
 [custom_csrs]
 fc0     m       custom_ro       const="32'h dead_beef"
@@ -78,3 +80,4 @@ f11     m       w
 [cover]
 always @* if (!reset) cover (channel[0].cnt_insns == 2);
 always @* if (!reset) cover (rvfi_csr_mstatus_rdata[3] != 0 && rvfi_valid == 1);
+always @* if (!reset) cover (rvfi_csr_mhpmevent3_rdata && rvfi_valid == 1);

--- a/checks.cfg
+++ b/checks.cfg
@@ -36,6 +36,7 @@ bus_dmem_fault      1    10
 csrc_zero  1    5
 csrc_any   1    5
 csrc_inc   1    5
+csrc_const 1    5
 
 [sort]
 reg_ch0
@@ -45,12 +46,12 @@ mcause
 mcycle          inc
 mscratch        any
 minstret        inc
-misa            zero
+misa            zero const="32'h 0"
 mstatus
-mvendorid
+mvendorid       const
 
 [custom_csrs]
-fc0     m       custom_ro
+fc0     m       custom_ro       const="32'h dead_beef"
 bc0     mu      custom          any
 
 [defines]

--- a/checks.cfg
+++ b/checks.cfg
@@ -28,6 +28,7 @@ causal     5    10
 cover      1    10
 ill             10
 csrw            10
+csr_ill         10
 
 bus_imem            1    10
 bus_imem_fault      1    10
@@ -53,6 +54,10 @@ mvendorid       const
 [custom_csrs]
 fc0     m       custom_ro       const="32'h dead_beef"
 bc0     mu      custom          any
+
+[illegal_csrs]
+fff     msu     rw
+f11     m       w
 
 [defines]
 `define YOSYS // Hotfix for older Tabby CAD Releases

--- a/firmware.s
+++ b/firmware.s
@@ -56,6 +56,20 @@ addi x31, zero, 0
 # place SP at the end of RAM
 li sp, 0x00010000
 
+# set vector table address and vectored mode
+la a0, __vector_start
+ori a0, a0, 0x1
+csrw mtvec, a0
+
+# enable all interrupts
+li a0, 0xffffffff
+csrw mie, a0
+
+# set mie bit
+csrr a0, mstatus
+ori a0, a0, 0x8
+csrw mstatus, a0
+
 # copy data section
 la a0, _sidata
 la a1, _sdata
@@ -82,5 +96,11 @@ end_init_bss:
 # call main
 call main
 
+#ecall
+#wfi
+
 # halt
 ebreak
+
+end_of_file:
+j end_of_file

--- a/nerv.sv
+++ b/nerv.sv
@@ -172,108 +172,113 @@
 `endif
 
 `define NERV_COUNTER_CSRS /* Machine Counter/Timers CSRs */				\
-	`NERV_CSR_REG_MRW(mcycle,            12'h B00, 32'h 0000_0000)			\
-	`NERV_CSR_REG_MRW(minstret,          12'h B02, 32'h 0000_0000)			\
+	`NERV_CSR_ARR_DEF(hpm_counter, 32)						\
+	`NERV_CSR_ARR_MRW(hpm_counter, 0, mcycle,            12'h B00)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 2, minstret,          12'h B02)			\
 											\
-	/* mhpmcounter3..31 can be readonly 0, provided the event CSR is too */		\
-	`NERV_CSR_VAL_MRW(mhpmcounter3,      12'h B03, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter4,      12'h B04, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter5,      12'h B05, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter6,      12'h B06, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter7,      12'h B07, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter8,      12'h B08, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter9,      12'h B09, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter10,     12'h B0A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter11,     12'h B0B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter12,     12'h B0C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter13,     12'h B0D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter14,     12'h B0E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter15,     12'h B0F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter16,     12'h B10, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter17,     12'h B11, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter18,     12'h B12, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter19,     12'h B13, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter20,     12'h B14, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter21,     12'h B15, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter22,     12'h B16, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter23,     12'h B17, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter24,     12'h B18, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter25,     12'h B19, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter26,     12'h B1A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter27,     12'h B1B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter28,     12'h B1C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter29,     12'h B1D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter30,     12'h B1E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter31,     12'h B1F, 32'h 0000_0000)			\
+	/* mhpmcounter3..31 provide hardware performance monitoring */ 			\
+	/* the counted event is defined by the corresponding hpm_event CSR */		\
+	`NERV_CSR_ARR_MRW(hpm_counter, 3,  mhpmcounter3,     12'h B03)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 4,  mhpmcounter4,     12'h B04)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 5,  mhpmcounter5,     12'h B05)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 6,  mhpmcounter6,     12'h B06)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 7,  mhpmcounter7,     12'h B07)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 8,  mhpmcounter8,     12'h B08)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 9,  mhpmcounter9,     12'h B09)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 10, mhpmcounter10,    12'h B0A)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 11, mhpmcounter11,    12'h B0B)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 12, mhpmcounter12,    12'h B0C)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 13, mhpmcounter13,    12'h B0D)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 14, mhpmcounter14,    12'h B0E)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 15, mhpmcounter15,    12'h B0F)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 16, mhpmcounter16,    12'h B10)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 17, mhpmcounter17,    12'h B11)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 18, mhpmcounter18,    12'h B12)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 19, mhpmcounter19,    12'h B13)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 20, mhpmcounter20,    12'h B14)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 21, mhpmcounter21,    12'h B15)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 22, mhpmcounter22,    12'h B16)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 23, mhpmcounter23,    12'h B17)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 24, mhpmcounter24,    12'h B18)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 25, mhpmcounter25,    12'h B19)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 26, mhpmcounter26,    12'h B1A)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 27, mhpmcounter27,    12'h B1B)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 28, mhpmcounter28,    12'h B1C)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 29, mhpmcounter29,    12'h B1D)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 30, mhpmcounter30,    12'h B1E)			\
+	`NERV_CSR_ARR_MRW(hpm_counter, 31, mhpmcounter31,    12'h B1F)			\
 											\
-	`NERV_CSR_REG_MRW(mcycleh,           12'h B80, 32'h 0000_0000)			\
-	`NERV_CSR_REG_MRW(minstreth,         12'h B82, 32'h 0000_0000)			\
+	`NERV_CSR_ARR_DEF(hpm_counterh, 32)						\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 0, mcycleh,          12'h B80)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 2, minstreth,        12'h B82)			\
 											\
-	`NERV_CSR_VAL_MRW(mhpmcounter3h,     12'h B83, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter4h,     12'h B84, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter5h,     12'h B85, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter6h,     12'h B86, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter7h,     12'h B87, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter8h,     12'h B88, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter9h,     12'h B89, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter10h,    12'h B8A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter11h,    12'h B8B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter12h,    12'h B8C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter13h,    12'h B8D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter14h,    12'h B8E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter15h,    12'h B8F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter16h,    12'h B90, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter17h,    12'h B91, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter18h,    12'h B92, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter19h,    12'h B93, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter20h,    12'h B94, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter21h,    12'h B95, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter22h,    12'h B96, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter23h,    12'h B97, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter24h,    12'h B98, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter25h,    12'h B99, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter26h,    12'h B9A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter27h,    12'h B9B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter28h,    12'h B9C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter29h,    12'h B9D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter30h,    12'h B9E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter31h,    12'h B9F, 32'h 0000_0000)
+	`NERV_CSR_ARR_MRW(hpm_counterh, 3,  mhpmcounter3h,   12'h B83)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 4,  mhpmcounter4h,   12'h B84)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 5,  mhpmcounter5h,   12'h B85)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 6,  mhpmcounter6h,   12'h B86)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 7,  mhpmcounter7h,   12'h B87)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 8,  mhpmcounter8h,   12'h B88)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 9,  mhpmcounter9h,   12'h B89)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 10, mhpmcounter10h,  12'h B8A)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 11, mhpmcounter11h,  12'h B8B)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 12, mhpmcounter12h,  12'h B8C)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 13, mhpmcounter13h,  12'h B8D)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 14, mhpmcounter14h,  12'h B8E)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 15, mhpmcounter15h,  12'h B8F)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 16, mhpmcounter16h,  12'h B90)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 17, mhpmcounter17h,  12'h B91)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 18, mhpmcounter18h,  12'h B92)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 19, mhpmcounter19h,  12'h B93)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 20, mhpmcounter20h,  12'h B94)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 21, mhpmcounter21h,  12'h B95)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 22, mhpmcounter22h,  12'h B96)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 23, mhpmcounter23h,  12'h B97)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 24, mhpmcounter24h,  12'h B98)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 25, mhpmcounter25h,  12'h B99)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 26, mhpmcounter26h,  12'h B9A)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 27, mhpmcounter27h,  12'h B9B)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 28, mhpmcounter28h,  12'h B9C)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 29, mhpmcounter29h,  12'h B9D)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 30, mhpmcounter30h,  12'h B9E)			\
+	`NERV_CSR_ARR_MRW(hpm_counterh, 31, mhpmcounter31h,  12'h B9F)		
 
 `define NERV_COUNTER_SETUP_CSRS /* Machine Counter Setup CSRs */			\
 	/* mcountinhibit is optional */							\
-/*	`NERV_CSR_VAL_MRW(mcountinhibit,     12'h 320, 32'h 0000_0000) */		\
+/*	`NERV_CSR_REG_MRW(mcountinhibit,     12'h 320, 32'h 0000_0000) */		\
 											\
-	/* mhpmevent3..31 can be readonly 0 */						\
-	`NERV_CSR_VAL_MRW(mhpmevent3,        12'h 323, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent4,        12'h 324, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent5,        12'h 325, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent6,        12'h 326, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent7,        12'h 327, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent8,        12'h 328, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent9,        12'h 329, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent10,       12'h 32A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent11,       12'h 32B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent12,       12'h 32C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent13,       12'h 32D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent14,       12'h 32E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent15,       12'h 32F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent16,       12'h 330, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent17,       12'h 331, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent18,       12'h 332, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent19,       12'h 333, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent20,       12'h 334, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent21,       12'h 335, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent22,       12'h 336, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent23,       12'h 337, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent24,       12'h 338, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent25,       12'h 339, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent26,       12'h 33A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent27,       12'h 33B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent28,       12'h 33C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent29,       12'h 33D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent30,       12'h 33E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent31,       12'h 33F, 32'h 0000_0000)
-
+	/* mhpmevent3..31 select which hardware event the corresponding */		\
+	/* mhpmcounter should be triggered by and thus count */				\
+	`NERV_CSR_ARR_DEF(hpm_event, 32)						\
+	`NERV_CSR_ARR_MRW(hpm_event, 3,  mhpmevent3,         12'h 323)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 4,  mhpmevent4,         12'h 324)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 5,  mhpmevent5,         12'h 325)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 6,  mhpmevent6,         12'h 326)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 7,  mhpmevent7,         12'h 327)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 8,  mhpmevent8,         12'h 328)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 9,  mhpmevent9,         12'h 329)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 10, mhpmevent10,        12'h 32A)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 11, mhpmevent11,        12'h 32B)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 12, mhpmevent12,        12'h 32C)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 13, mhpmevent13,        12'h 32D)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 14, mhpmevent14,        12'h 32E)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 15, mhpmevent15,        12'h 32F)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 16, mhpmevent16,        12'h 330)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 17, mhpmevent17,        12'h 331)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 18, mhpmevent18,        12'h 332)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 19, mhpmevent19,        12'h 333)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 20, mhpmevent20,        12'h 334)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 21, mhpmevent21,        12'h 335)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 22, mhpmevent22,        12'h 336)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 23, mhpmevent23,        12'h 337)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 24, mhpmevent24,        12'h 338)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 25, mhpmevent25,        12'h 339)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 26, mhpmevent26,        12'h 33A)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 27, mhpmevent27,        12'h 33B)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 28, mhpmevent28,        12'h 33C)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 29, mhpmevent29,        12'h 33D)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 30, mhpmevent30,        12'h 33E)			\
+	`NERV_CSR_ARR_MRW(hpm_event, 31, mhpmevent31,        12'h 33F)
+ 
 `define NERV_CUSTOM_CSRS /* Custom CSR for testing */					\
 	`NERV_CSR_REG_MRW(custom,            12'h BC0, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRO(custom_ro,         12'h FC0, 32'h dead_beef)
@@ -330,10 +335,20 @@ module nerv #(
 `define NERV_CSR_VAL_MRO(NAME, ADDR, VALUE)			\
 	`NERV_CSR_REG_MRW(NAME, ADDR, VALUE)
 
+`define NERV_CSR_ARR_DEF(ARRAY, DEPTH)
+
+`define NERV_CSR_ARR_MRW(ARRAY, INDEX, NAME, ADDR)		\
+	output reg [31:0] rvfi_csr_``NAME``_rmask,			\
+	output reg [31:0] rvfi_csr_``NAME``_wmask,			\
+	output reg [31:0] rvfi_csr_``NAME``_rdata,			\
+	output reg [31:0] rvfi_csr_``NAME``_wdata,
+
 `NERV_CSRS
 `undef NERV_CSR_REG_MRW
 `undef NERV_CSR_VAL_MRW
 `undef NERV_CSR_VAL_MRO
+`undef NERV_CSR_ARR_DEF
+`undef NERV_CSR_ARR_MRW
 `endif
 
 	output reg [31:0] rvfi_mem_addr,
@@ -554,6 +569,8 @@ module nerv #(
 	wire [31:0] csr_rsval = insn_funct3[2] ? insn_rs1 : rs1_value;
 	wire csr_ro = csr_mode && (csr_mode != 2'b01 && !insn_rs1);
 
+	integer hpm_idx, hpm_increment, hpm_event;
+
 `define NERV_CSR_REG_MRW(NAME, ADDR, VALUE)				\
 	wire csr_``NAME``_sel = csr_mode && csr_addr == ADDR;		\
 	reg [31:0] csr_``NAME``_value;					\
@@ -574,11 +591,36 @@ module nerv #(
 	wire csr_``NAME``_sel = csr_ro && csr_addr == ADDR;		\
 	localparam [31:0] csr_``NAME``_value = VALUE;
 
+`define NERV_CSR_ARR_DEF(ARRAY, DEPTH)					\
+	integer ARRAY``_idx;						\
+	wire [DEPTH-1:0] csr_``ARRAY``_sel;			\
+	reg [(DEPTH*32)-1:0] csr_``ARRAY``_value;			\
+	reg [(DEPTH*32)-1:0] csr_``ARRAY``_wdata;			\
+	reg [(DEPTH*32)-1:0] csr_``ARRAY``_next;			\
+	always @(posedge clock) begin					\
+		csr_``ARRAY``_value <= csr_``ARRAY``_next;		\
+		if (reset || reset_q)					\
+			csr_``ARRAY``_value <= 'b0;			\
+	end
+
+`define NERV_CSR_ARR_MRW(ARRAY, INDEX, NAME, ADDR)				\
+	wire csr_``NAME``_sel = csr_mode && csr_addr == ADDR;			\
+	wire [31:0] csr_``NAME``_value = csr_``ARRAY``_value[(INDEX)*32 +: 32];	\
+	wire [31:0] csr_``NAME``_wdata = csr_``ARRAY``_wdata[(INDEX)*32 +: 32];	\
+	wire [31:0] csr_``NAME``_next  = csr_``ARRAY``_next[(INDEX)*32 +: 32];  \
+	assign csr_``ARRAY``_sel[INDEX] = csr_``NAME``_sel;
+
+	// dummy out missing select lines
+	assign csr_hpm_event_sel[2:0] = 0;
+	assign csr_hpm_counter_sel[1] = 0;
+	assign csr_hpm_counterh_sel[1] = 0;
+
 `NERV_CSRS
 `undef NERV_CSR_REG_MRW
 `undef NERV_CSR_VAL_MRW
 `undef NERV_CSR_VAL_MRO
-
+`undef NERV_CSR_ARR_DEF
+`undef NERV_CSR_ARR_MRW
 `endif // NERV_CSR
 
 	wire [31:0] irq_en;
@@ -659,11 +701,16 @@ module nerv #(
 				csr_ack = 1;				\
 				csr_rdval = csr_``NAME``_value;	\
 			end
+`define NERV_CSR_ARR_DEF(ARRAY, DEPTH)
+`define NERV_CSR_ARR_MRW(ARRAY, INDEX, NAME, ADDR)		\
+	`NERV_CSR_REG_MRW(NAME, ADDR, 32'h 0000_0000)
 
 `NERV_CSRS
 `undef NERV_CSR_REG_MRW
 `undef NERV_CSR_VAL_MRW
 `undef NERV_CSR_VAL_MRO
+`undef NERV_CSR_ARR_DEF
+`undef NERV_CSR_ARR_MRW
 
 			default: /* nothing */;
 		endcase
@@ -681,16 +728,41 @@ module nerv #(
 
 `define NERV_CSR_VAL_MRW(NAME, ADDR, VALUE)
 `define NERV_CSR_VAL_MRO(NAME, ADDR, VALUE)
+`define NERV_CSR_ARR_DEF(ARRAY, DEPTH)								\
+		for (ARRAY``_idx=0; ARRAY``_idx < DEPTH; ARRAY``_idx=ARRAY``_idx+1) begin 	\
+			csr_``ARRAY``_wdata[(ARRAY``_idx)*32 +: 32] = 				\
+				csr_``ARRAY``_sel[ARRAY``_idx] 					\
+				? csr_next 							\
+				: csr_``ARRAY``_value[(ARRAY``_idx)*32 +: 32];			\
+		end										\
+		csr_``ARRAY``_next = csr_``ARRAY``_wdata;
+
+`define NERV_CSR_ARR_MRW(ARRAY, INDEX, NAME, ADDR)
 
 `NERV_CSRS
 `undef NERV_CSR_REG_MRW
 `undef NERV_CSR_VAL_MRW
 `undef NERV_CSR_VAL_MRO
+`undef NERV_CSR_ARR_DEF
+`undef NERV_CSR_ARR_MRW
 
-		{csr_mcycleh_next, csr_mcycle_next} = {csr_mcycleh_next, csr_mcycle_next} + 1;
-
-		if (running) begin
-			{csr_minstreth_next, csr_minstret_next} = {csr_minstreth_next, csr_minstret_next} + 1;
+		for (hpm_idx=0; hpm_idx < 32; hpm_idx=hpm_idx+1) begin
+			case (hpm_idx)
+				0 /* mcycle */ : hpm_event = 32'h 1;
+				2 /* minstret */ : hpm_event = 32'h 2;
+				default:
+					hpm_event = csr_hpm_event_next[(hpm_idx)*32 +: 32];
+			endcase
+			case (hpm_event)
+				32'h 1 /* cycle counter */: hpm_increment = 1;
+				32'h 2 /* instruction counter */: hpm_increment = running ? 1 : 0;
+				default: begin
+					csr_hpm_event_next[(hpm_idx)*32 +: 32] = 0;
+					hpm_increment = 0;
+				end
+			endcase
+			{csr_hpm_counterh_next[(hpm_idx)*32 +: 32], csr_hpm_counter_next[(hpm_idx)*32 +: 32]} = 
+				{csr_hpm_counterh_next[(hpm_idx)*32 +: 32], csr_hpm_counter_next[(hpm_idx)*32 +: 32]} + hpm_increment;
 		end
 
 	// mstatus & mstatush - Machine Status
@@ -1125,10 +1197,16 @@ module nerv #(
 			rvfi_csr_``NAME``_rdata <= csr_``NAME``_value;	\
 			rvfi_csr_``NAME``_wdata <= csr_``NAME``_value;
 
+`define NERV_CSR_ARR_DEF(ARRAY, DEPTH)
+`define NERV_CSR_ARR_MRW(ARRAY, INDEX, NAME, ADDR) \
+	`NERV_CSR_REG_MRW(NAME, ADDR, 32'h 0000_0000)
+
 `NERV_CSRS
 `undef NERV_CSR_REG_MRW
 `undef NERV_CSR_VAL_MRW
 `undef NERV_CSR_VAL_MRO
+`undef NERV_CSR_ARR_DEF
+`undef NERV_CSR_ARR_MRW
 `endif
 		end
 `endif

--- a/nerv.sv
+++ b/nerv.sv
@@ -31,6 +31,7 @@
 	// FIXME: Additional instructions: ECALL, EBREAK, MRET, WFI
 
 `define NERV_MACHINE_CSRS /* Machine Information CSRs */				\
+	/* all of these CSRs are mandatory but can legally be all 0 */			\
 	`NERV_CSR_VAL_MRO(mvendorid,         12'h F11, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRO(marchid,           12'h F12, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRO(mimpid,            12'h F13, 32'h 0000_0000)			\
@@ -38,26 +39,50 @@
 	`NERV_CSR_VAL_MRO(mconfigptr,        12'h F15, 32'h 0000_0000)
 
 `define NERV_TRAP_SETUP_CSRS /* Machine Trap Setup CSRs */				\
-	`NERV_CSR_REG_MRW(mstatus,           12'h 300, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_VAL_MRW(misa,              12'h 301, 32'h 4000_0100)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(medeleg,           12'h 302, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mideleg,           12'h 303, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mie,               12'h 304, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mtvec,             12'h 305, 32'h 0000_0000)   /* FIXME */	\
-/*	`NERV_CSR_REG_MRW(mcounteren,        12'h 306, 32'h 0000_0000) */
-/*	`NERV_CSR_REG_MRW(mstatush,          12'h 310, 32'h 0000_0000) */
+	`NERV_CSR_REG_MRW(mstatus,           12'h 300, 32'h 0000_0000)			\
+											\
+	/* misa can legally return all zeros */						\
+	`NERV_CSR_REG_MRW(misa,              12'h 301, 32'h 0000_0000)			\
+											\
+	/* medeleg and mideleg should only exist if S mode is available */		\
+/*	`NERV_CSR_REG_MRW(medeleg,           12'h 302, 32'h 0000_0000) */  		\
+/*	`NERV_CSR_REG_MRW(mideleg,           12'h 303, 32'h 0000_0000) */  		\
+											\
+	`NERV_CSR_REG_MRW(mie,               12'h 304, 32'h 0000_0000)			\
+											\
+	/* mtvec can be implemented as read-only */					\
+	`NERV_CSR_REG_MRW(mtvec,             12'h 305, 32'h 0000_0000)			\
+											\
+	/* mcounteren should only exist if U mode is available */			\
+/*	`NERV_CSR_REG_MRW(mcounteren,        12'h 306, 32'h 0000_0000) */		\
+											\
+	`NERV_CSR_REG_MRW(mstatush,          12'h 310, 32'h 0000_0000)
 
 `define NERV_TRAP_HANDLING_CSRS /* Machine Trap Handling CSRs */			\
 	`NERV_CSR_REG_MRW(mscratch,          12'h 340, 32'h 0000_0000)	 		\
-	`NERV_CSR_REG_MRW(mepc,              12'h 341, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mcause,            12'h 342, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mtval,             12'h 343, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mip,               12'h 344, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mtinst,            12'h 34A, 32'h 0000_0000)   /* FIXME */	\
-	`NERV_CSR_REG_MRW(mtval2,            12'h 34B, 32'h 0000_0000)   /* FIXME */
+	`NERV_CSR_REG_MRW(mepc,              12'h 341, 32'h 0000_0000)			\
+	`NERV_CSR_REG_MRW(mcause,            12'h 342, 32'h 0000_0000)			\
+	`NERV_CSR_REG_MRW(mtval,             12'h 343, 32'h 0000_0000)			\
+	`NERV_CSR_REG_MRW(mip,               12'h 344, 32'h 0000_0000)			\
+											\
+	/* mtinst and mtval2 added by hypervisor extension */				\
+/*	`NERV_CSR_REG_MRW(mtinst,            12'h 34A, 32'h 0000_0000) */		\
+/*	`NERV_CSR_REG_MRW(mtval2,            12'h 34B, 32'h 0000_0000) */
+
+`define NERV_MACHINE_CONFIG_CSRS /* machine configuration CSRs */			\
+	/* menvcfg should only exist if U mode is available */				\
+/*	`NERV_CSR_REG_MRW(menvcfg,           12'h 30A, 32'h 0000_0000) */		\
+/*	`NERV_CSR_REG_MRW(menvcfgh,          12'h 31A, 32'h 0000_0000) */		\
+											\
+	/* mseccfg not yet fully defined, and is not currently required */		\
+/*	`NERV_CSR_REG_MRW(mseccfg,           12'h 747, 32'h 0000_0000) */		\
+/*	`NERV_CSR_REG_MRW(mseccfgh,          12'h 757, 32'h 0000_0000) */
 
 `ifdef NERV_PMP
+/* PMP is optional and can be implemented with 0, 16, or 64 address CSRS */
 `define NERV_PMP_CFG_CSRS /* Machine Memory Protection Config CSRs */			\
+	/* PMP configuration is 8-bits long, */						\
+	/* so each cfg controls four PMPs in RV32 */					\
 	`NERV_CSR_VAL_MRW(pmpcfg0,           12'h 3A0, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRW(pmpcfg1,           12'h 3A1, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRW(pmpcfg2,           12'h 3A2, 32'h 0000_0000)			\
@@ -139,7 +164,8 @@
 	`NERV_CSR_VAL_MRW(pmpaddr60,         12'h 3EC, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRW(pmpaddr61,         12'h 3ED, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRW(pmpaddr62,         12'h 3EE, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(pmpaddr63,         12'h 3EF, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(pmpaddr63,         12'h 3EF, 32'h 0000_0000)
+
 `else
 `define NERV_PMP_CFG_CSRS
 `define NERV_PMP_ADDR_CSRS
@@ -149,105 +175,110 @@
 	`NERV_CSR_REG_MRW(mcycle,            12'h B00, 32'h 0000_0000)			\
 	`NERV_CSR_REG_MRW(minstret,          12'h B02, 32'h 0000_0000)			\
 											\
-	`NERV_CSR_VAL_MRW(mhpmcounter3,      12'h B03, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter4,      12'h B04, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter5,      12'h B05, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter6,      12'h B06, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter7,      12'h B07, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter8,      12'h B08, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter9,      12'h B09, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter10,     12'h B0A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter11,     12'h B0B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter12,     12'h B0C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter13,     12'h B0D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter14,     12'h B0E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter15,     12'h B0F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter16,     12'h B10, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter17,     12'h B11, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter18,     12'h B12, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter19,     12'h B13, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter20,     12'h B14, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter21,     12'h B15, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter22,     12'h B16, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter23,     12'h B17, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter24,     12'h B18, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter25,     12'h B19, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter26,     12'h B1A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter27,     12'h B1B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter28,     12'h B1C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter29,     12'h B1D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter30,     12'h B1E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter31,     12'h B1F, 32'h 0000_0000)			\
-	                        							\
+	/* mhpmcounter3..31 can be readonly 0, provided the event CSR is too */		\
+	`NERV_CSR_VAL_MRO(mhpmcounter3,      12'h B03, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter4,      12'h B04, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter5,      12'h B05, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter6,      12'h B06, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter7,      12'h B07, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter8,      12'h B08, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter9,      12'h B09, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter10,     12'h B0A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter11,     12'h B0B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter12,     12'h B0C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter13,     12'h B0D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter14,     12'h B0E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter15,     12'h B0F, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter16,     12'h B10, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter17,     12'h B11, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter18,     12'h B12, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter19,     12'h B13, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter20,     12'h B14, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter21,     12'h B15, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter22,     12'h B16, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter23,     12'h B17, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter24,     12'h B18, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter25,     12'h B19, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter26,     12'h B1A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter27,     12'h B1B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter28,     12'h B1C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter29,     12'h B1D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter30,     12'h B1E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter31,     12'h B1F, 32'h 0000_0000)			\
+											\
 	`NERV_CSR_REG_MRW(mcycleh,           12'h B80, 32'h 0000_0000)			\
 	`NERV_CSR_REG_MRW(minstreth,         12'h B82, 32'h 0000_0000)			\
-	                        							\
-	`NERV_CSR_VAL_MRW(mhpmcounter3h,     12'h B83, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter4h,     12'h B84, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter5h,     12'h B85, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter6h,     12'h B86, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter7h,     12'h B87, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter8h,     12'h B88, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter9h,     12'h B89, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter10h,    12'h B8A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter11h,    12'h B8B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter12h,    12'h B8C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter13h,    12'h B8D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter14h,    12'h B8E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter15h,    12'h B8F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter16h,    12'h B90, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter17h,    12'h B91, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter18h,    12'h B92, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter19h,    12'h B93, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter20h,    12'h B94, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter21h,    12'h B95, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter22h,    12'h B96, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter23h,    12'h B97, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter24h,    12'h B98, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter25h,    12'h B99, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter26h,    12'h B9A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter27h,    12'h B9B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter28h,    12'h B9C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter29h,    12'h B9D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter30h,    12'h B9E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmcounter31h,    12'h B9F, 32'h 0000_0000)
+											\
+	`NERV_CSR_VAL_MRO(mhpmcounter3h,     12'h B83, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter4h,     12'h B84, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter5h,     12'h B85, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter6h,     12'h B86, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter7h,     12'h B87, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter8h,     12'h B88, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter9h,     12'h B89, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter10h,    12'h B8A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter11h,    12'h B8B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter12h,    12'h B8C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter13h,    12'h B8D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter14h,    12'h B8E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter15h,    12'h B8F, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter16h,    12'h B90, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter17h,    12'h B91, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter18h,    12'h B92, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter19h,    12'h B93, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter20h,    12'h B94, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter21h,    12'h B95, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter22h,    12'h B96, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter23h,    12'h B97, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter24h,    12'h B98, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter25h,    12'h B99, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter26h,    12'h B9A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter27h,    12'h B9B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter28h,    12'h B9C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter29h,    12'h B9D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter30h,    12'h B9E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmcounter31h,    12'h B9F, 32'h 0000_0000)
 
 `define NERV_COUNTER_SETUP_CSRS /* Machine Counter Setup CSRs */			\
+	/* mcountinhibit is optional */							\
 /*	`NERV_CSR_VAL_MRW(mcountinhibit,     12'h 320, 32'h 0000_0000) */		\
-	`NERV_CSR_VAL_MRW(mhpmevent3,        12'h 323, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent4,        12'h 324, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent5,        12'h 325, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent6,        12'h 326, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent7,        12'h 327, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent8,        12'h 328, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent9,        12'h 329, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent10,       12'h 32A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent11,       12'h 32B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent12,       12'h 32C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent13,       12'h 32D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent14,       12'h 32E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent15,       12'h 32F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent16,       12'h 330, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent17,       12'h 331, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent18,       12'h 332, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent19,       12'h 333, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent20,       12'h 334, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent21,       12'h 335, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent22,       12'h 336, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent23,       12'h 337, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent24,       12'h 338, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent25,       12'h 339, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent26,       12'h 33A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent27,       12'h 33B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent28,       12'h 33C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent29,       12'h 33D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent30,       12'h 33E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRW(mhpmevent31,       12'h 33F, 32'h 0000_0000)
+											\
+	/* mhpmevent3..31 can be readonly 0 */						\
+	`NERV_CSR_VAL_MRO(mhpmevent3,        12'h 323, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent4,        12'h 324, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent5,        12'h 325, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent6,        12'h 326, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent7,        12'h 327, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent8,        12'h 328, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent9,        12'h 329, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent10,       12'h 32A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent11,       12'h 32B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent12,       12'h 32C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent13,       12'h 32D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent14,       12'h 32E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent15,       12'h 32F, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent16,       12'h 330, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent17,       12'h 331, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent18,       12'h 332, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent19,       12'h 333, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent20,       12'h 334, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent21,       12'h 335, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent22,       12'h 336, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent23,       12'h 337, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent24,       12'h 338, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent25,       12'h 339, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent26,       12'h 33A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent27,       12'h 33B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent28,       12'h 33C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent29,       12'h 33D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent30,       12'h 33E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(mhpmevent31,       12'h 33F, 32'h 0000_0000)
 
 `define NERV_CSRS			\
 	`NERV_MACHINE_CSRS		\
 	`NERV_TRAP_SETUP_CSRS		\
 	`NERV_TRAP_HANDLING_CSRS	\
+	`NERV_MACHINE_CONFIG_CSRS	\
 	`NERV_PMP_CFG_CSRS		\
 	`NERV_PMP_ADDR_CSRS		\
 	`NERV_COUNTER_CSRS		\
@@ -256,14 +287,11 @@
 
 module nerv #(
 	parameter [31:0] RESET_ADDR = 32'h 0000_0000,
-	parameter [31:0] NMI_ADDR = 32'h 0000_0004,
-	parameter [31:0] TRAP_ADDR = 32'h 0000_0008,
 	parameter integer NUMREGS = 32
 ) (
 	input clock,
 	input reset,
 	input stall,
-	input nmi,
 	output trap,
 
 `ifdef NERV_RVFI
@@ -320,7 +348,9 @@ module nerv #(
 	output [31:0] dmem_addr,
 	output [ 3:0] dmem_wstrb,
 	output [31:0] dmem_wdata,
-	input  [31:0] dmem_rdata
+	input  [31:0] dmem_rdata,
+	// interrupt inputs
+	input  [31:0] irq
 );
 	reg mem_wr_enable;
 	reg [31:0] mem_wr_addr;
@@ -443,6 +473,18 @@ module nerv #(
 	localparam OPCODE_CUSTOM_2   = 7'b 10_110_11;
 	localparam OPCODE_CUSTOM_3   = 7'b 11_110_11;
 
+	localparam MCAUSE_MACHINE_SOFTWARE_INTERRUPT = 32'h80000003;
+	localparam MCAUSE_MACHINE_TIMER_INTERRUPT    = 32'h80000007;
+	localparam MCAUSE_MACHINE_EXTERNAL_INTERRUPT = 32'h8000000b;
+
+	localparam MCAUSE_ADDRESS_MISALIGNED     = 32'h00000000;
+	localparam MCAUSE_ACCESS_FAULT           = 32'h00000001;
+	localparam MCAUSE_INVALID_INSTRUCTION    = 32'h00000002;
+	localparam MCAUSE_BREAKPOINT             = 32'h00000003;
+	localparam MCAUSE_ECALL_M_MODE           = 32'h0000000b;
+
+	localparam IRQ_MASK = 32'hFFFF0888;
+
 	// next write, next destination (rd) value & register
 	reg next_wr;
 	reg [31:0] next_rd;
@@ -461,9 +503,6 @@ module nerv #(
 	reg cycle_late_wr; // 2nd cycle for mem_rd_enable instructions
 
 	assign trap = cycle_trap;
-
-	reg nmi_pending;
-	reg nmi_pending_q;
 
 `ifdef NERV_CSR
 	/*********************
@@ -505,6 +544,34 @@ module nerv #(
 
 `endif // NERV_CSR
 
+	wire [31:0] irq_en;
+	reg [4:0] irq_num;
+	assign irq_en = irq & csr_mie_value;
+
+	// resolve interrupt priority
+	always @* begin
+		if (irq_en[31]) irq_num = 5'd31;
+		else if (irq_en[30]) irq_num = 5'd30;
+		else if (irq_en[29]) irq_num = 5'd29;
+		else if (irq_en[28]) irq_num = 5'd28;
+		else if (irq_en[27]) irq_num = 5'd27;
+		else if (irq_en[26]) irq_num = 5'd26;
+		else if (irq_en[25]) irq_num = 5'd25;
+		else if (irq_en[24]) irq_num = 5'd24;
+		else if (irq_en[23]) irq_num = 5'd23;
+		else if (irq_en[22]) irq_num = 5'd22;
+		else if (irq_en[21]) irq_num = 5'd21;
+		else if (irq_en[20]) irq_num = 5'd20;
+		else if (irq_en[19]) irq_num = 5'd19;
+		else if (irq_en[18]) irq_num = 5'd18;
+		else if (irq_en[17]) irq_num = 5'd17;
+		else if (irq_en[16]) irq_num = 5'd16;
+		else if (irq_en[11]) irq_num = 5'd11;
+		else if (irq_en[7]) irq_num = 5'd7;
+		else if (irq_en[3]) irq_num = 5'd3;
+		else irq_num = 5'd0;
+	end
+
 	always @* begin
 		// advance pc
 		npc = pc + 4;
@@ -519,7 +586,6 @@ module nerv #(
 		wr_rd = insn_rd;
 
 		illinsn = 0;
-		nmi_pending = nmi_pending_q;
 
 		mem_wr_enable = 0;
 		mem_wr_addr = 32'hx;
@@ -586,6 +652,85 @@ module nerv #(
 		if (running) begin
 			{csr_minstreth_next, csr_minstret_next} = {csr_minstreth_next, csr_minstret_next} + 1;
 		end
+
+	// mstatus & mstatush - Machine Status
+	csr_mstatus_next[31] = 'b0; // SD is always 0 if FS, VS, and XS are not enabled
+	csr_mstatus_next[30:23] = 'b0; // WPRI
+	csr_mstatus_next[22] = 'b0; // TSR = 0 if no S
+	csr_mstatus_next[21] = 'b0; // TW = 0 if no U or S
+	csr_mstatus_next[20] = 'b0; // TVM = 0 if no S
+	csr_mstatus_next[19] = 'b0; // MXR = 0 if no S
+	csr_mstatus_next[18] = 'b0; // SUM = 0 if no S
+	csr_mstatus_next[17] = 'b0; // MPRV = 0 if no U
+	csr_mstatus_next[16:15] = 'b0; // XS = 0 if no user extensions
+	csr_mstatus_next[14:13] = 'b0; // FS = 0 if no S and no floating point extension
+	csr_mstatus_next[12:11] = 2'b11; // MPP = b11 if no U
+	csr_mstatus_next[10:9] = 'b0; // VS = 0 if no vector extension
+	csr_mstatus_next[8] = 'b0; // SPP = 0 if no S
+	//csr_mstatus_next[7] = ; // MPIE controlled by trap handling
+	csr_mstatus_next[6] = 'b0; // UBE = 0 if no U
+	csr_mstatus_next[5] = 'b0; // SPIE = 0 if no S
+	csr_mstatus_next[4] = 'b0; // WPRI
+	//csr_mstatus_next[3] = ; // MIE controlled by code
+	csr_mstatus_next[2] = 'b0; // WPRI
+	csr_mstatus_next[1] = 'b0; // SIE = 0 if no S
+	csr_mstatus_next[0] = 'b0; // WPRI
+
+	csr_mstatush_next[31:6] = 'b0; // WPRI
+	csr_mstatush_next[5] = 1'b0; // MBE = 1 if big endian, 0 if little endian
+	csr_mstatush_next[4] = 'b0; // SBE = 0 if no S
+	csr_mstatush_next[3:0] = 'b0; // WPRI
+
+	// misa - Machine ISA
+	// read-only 0 for unimplemented register
+	csr_misa_next[31:20] = 'b0; // MXL = 1 for XLEN=32
+	csr_misa_next[29:26] = 'b0; // 0
+	csr_misa_next[25:0] = 'b0; // Extensions enabled
+
+	// mie - Machine Interrupt-Enable
+	// A bit in mie must be writable if the corresponding interrupt can ever become pending.
+	// Bits of mie that are not writable must be read-only 0.
+	//csr_mie_next[31:16] = 'b0; // bits 16 and above for custom/platform interrupts
+	csr_mie_next[15:12] = 'b0; // 0
+	//csr_mie_next[11] = 'b0; // MEIE - Machine-level External Interrupt Enable
+	csr_mie_next[10] = 'b0; // 0
+	csr_mie_next[9] = 'b0; // SEIE = 0 if no S
+	csr_mie_next[8] = 'b0; // 0
+	//csr_mie_next[7] = 'b0; // MTIE - Machine Timer Interrupt Enable
+	csr_mie_next[6] = 'b0; // 0
+	csr_mie_next[5] = 'b0; // STIE = 0 if no S
+	csr_mie_next[4] = 'b0; // 0
+	//csr_mie_next[3] = 'b0; // MSIE - Machine-level Software Interrupt Enable
+	csr_mie_next[2] = 'b0; // 0
+	csr_mie_next[1] = 'b0; // SSIE = 0 if no S
+	csr_mie_next[0] = 'b0; // 0
+
+	// mip - Machine Interrupt-Pending
+	//csr_mip_next[31:16] = 'b0; // bits 16 and above for custom/platform interrupts
+	//csr_mip_next[15:12] = 'b0; // 0
+	//csr_mip_next[11] = 'b0; // MEIE - Machine-level External Interrupt Pending
+	//csr_mip_next[10] = 'b0; // 0
+	//csr_mip_next[9] = 'b0; // SEIE = 0 if no S
+	//csr_mip_next[8] = 'b0; // 0
+	//csr_mip_next[7] = 'b0; // MTIE - Machine Timer Interrupt Pending
+	//csr_mip_next[6] = 'b0; // 0
+	//csr_mip_next[5] = 'b0; // STIE = 0 if no S
+	//csr_mip_next[4] = 'b0; // 0
+	//csr_mip_next[3] = 'b0; // MSIE - Machine-level Software Interrupt Pending
+	//csr_mip_next[2] = 'b0; // 0
+	//csr_mip_next[1] = 'b0; // SSIE = 0 if no S
+	//csr_mip_next[0] = 'b0; // 0
+	csr_mip_next = irq & IRQ_MASK;
+
+	// mtvec - Machine Trap-Vector Base-Address
+	csr_mtvec_next[1] = 'b0; // MODE - keep high bit always 0
+
+	// mcause - keep these bits at 0
+	csr_mcause_next[30:5] ='b0;
+
+	// mepc - keep alignment
+	csr_mepc_next[1:0] = 'b0;
+
 `endif // NERV_CSR
 
 		// act on opcodes
@@ -715,24 +860,55 @@ module nerv #(
 			end
 `ifdef NERV_CSR
 			OPCODE_SYSTEM: begin
-				if (csr_ack) begin
-					next_wr = 1;
-					next_rd = csr_rdval;
-				end else
-					illinsn = 1;
+				case (insn_funct3)
+					3'b 000 : begin
+						case ({insn_funct7, insn_rs2})
+							12'b 0000000_00000 /* ECALL */:
+								begin
+									csr_mepc_next = { pc[31:2], 2'b00 };
+									npc = csr_mtvec_value & ~3;
+									csr_mcause_next = MCAUSE_ECALL_M_MODE;
+									csr_mstatus_next[7] = csr_mstatus_value[3];  // save MIE to MPIE
+									csr_mstatus_next[3] = 0; // MIE to 0
+								end
+							12'b 0000000_00001 /* EBREAK */:
+								begin
+									csr_mepc_next = { pc[31:2], 2'b00 };
+									npc = csr_mtvec_value & ~3;
+									csr_mcause_next = MCAUSE_BREAKPOINT;
+									csr_mstatus_next[7] = csr_mstatus_value[3];  // save MIE to MPIE
+									csr_mstatus_next[3] = 0; // MIE to 0
+								end
+							12'b 0011000_00010 /* MRET */:
+								begin
+									npc = csr_mepc_value;
+									csr_mcause_next = 'b0;
+									csr_mstatus_next[3] = csr_mstatus_value[7];  // restore MIE from MPIE
+								end
+							12'b 0001000_00101 /* WFI */:
+								begin
+									// implemented as NOP
+								end
+							default: illinsn = 1;
+						endcase
+					end
+					default : begin
+						if (csr_ack) begin
+							next_wr = 1;
+							next_rd = csr_rdval;
+						end else
+							illinsn = 1;
+					end
+				endcase
 			end
 `endif
 			default: illinsn = 1;
 		endcase
 
-		// check the nmi input every cycle
-		if (nmi)
-			nmi_pending = 1;
-
 		if (reset || reset_q) begin
 			// reset has the highest priority
 			npc = RESET_ADDR;
-			nmi_pending = 0;
+			csr_mstatus_next[3] = 0; // MIE
 		end else if (stall) begin
 			// if this is a stall cycle, don't perform any action
 			npc = pc;
@@ -742,15 +918,26 @@ module nerv #(
 			cycle_late_wr = 1;
 			wr_rd = mem_rd_reg_q;
 			next_rd = mem_rdata;
-		end else if (nmi_pending) begin
-			// if an NMI is pending, take the interrupt
+		end else if (irq_num!=0) begin
+			// if there's a pending IRQ, take it
+			csr_mepc_next = { pc[31:2], 2'b00 };
+			csr_mcause_next = 1 << 31 | irq_num;
+			if (csr_mtvec_value & 1)
+				npc = (csr_mtvec_value & ~3) + (irq_num << 2);
+			else
+				npc = csr_mtvec_value & ~3;
+			csr_mstatus_next[7] = 1; // MPIE to 1
+			csr_mstatus_next[3] = 0; // MIE to 0
+
 			cycle_intr = 1;
-			nmi_pending = 0;
-			npc = NMI_ADDR;
 		end else if (illinsn) begin
 			// if the instruction is invalid, take a trap
 			cycle_trap = 1;
-			npc = TRAP_ADDR;
+			csr_mepc_next[31:2] = pc[31:2];
+			npc = csr_mtvec_value & ~3;
+			csr_mcause_next = MCAUSE_INVALID_INSTRUCTION;
+			csr_mstatus_next[7] = csr_mstatus_value[3];  // save MIE to MPIE
+			csr_mstatus_next[3] = 0; // MIE to 0
 		end else begin
 			// the instruction is valid and nothing else has priority
 			cycle_insn = 1;
@@ -785,7 +972,6 @@ module nerv #(
 	// every cycle
 	always @(posedge clock) begin
 		reset_q <= reset || (reset_q && stall);
-		nmi_pending_q <= nmi_pending;
 
 		// update pc
 		pc <= npc;

--- a/nerv.sv
+++ b/nerv.sv
@@ -274,6 +274,10 @@
 	`NERV_CSR_VAL_MRO(mhpmevent30,       12'h 33E, 32'h 0000_0000)			\
 	`NERV_CSR_VAL_MRO(mhpmevent31,       12'h 33F, 32'h 0000_0000)
 
+`define NERV_CUSTOM_CSRS /* Custom CSR for testing */					\
+	`NERV_CSR_REG_MRW(custom,            12'h BC0, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRO(custom_ro,         12'h FC0, 32'h dead_beef)
+
 `define NERV_CSRS			\
 	`NERV_MACHINE_CSRS		\
 	`NERV_TRAP_SETUP_CSRS		\
@@ -282,7 +286,8 @@
 	`NERV_PMP_CFG_CSRS		\
 	`NERV_PMP_ADDR_CSRS		\
 	`NERV_COUNTER_CSRS		\
-	`NERV_COUNTER_SETUP_CSRS
+	`NERV_COUNTER_SETUP_CSRS	\
+	`NERV_CUSTOM_CSRS
 `endif
 
 module nerv #(

--- a/nerv.sv
+++ b/nerv.sv
@@ -176,103 +176,103 @@
 	`NERV_CSR_REG_MRW(minstret,          12'h B02, 32'h 0000_0000)			\
 											\
 	/* mhpmcounter3..31 can be readonly 0, provided the event CSR is too */		\
-	`NERV_CSR_VAL_MRO(mhpmcounter3,      12'h B03, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter4,      12'h B04, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter5,      12'h B05, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter6,      12'h B06, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter7,      12'h B07, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter8,      12'h B08, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter9,      12'h B09, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter10,     12'h B0A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter11,     12'h B0B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter12,     12'h B0C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter13,     12'h B0D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter14,     12'h B0E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter15,     12'h B0F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter16,     12'h B10, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter17,     12'h B11, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter18,     12'h B12, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter19,     12'h B13, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter20,     12'h B14, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter21,     12'h B15, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter22,     12'h B16, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter23,     12'h B17, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter24,     12'h B18, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter25,     12'h B19, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter26,     12'h B1A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter27,     12'h B1B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter28,     12'h B1C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter29,     12'h B1D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter30,     12'h B1E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter31,     12'h B1F, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter3,      12'h B03, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter4,      12'h B04, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter5,      12'h B05, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter6,      12'h B06, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter7,      12'h B07, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter8,      12'h B08, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter9,      12'h B09, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter10,     12'h B0A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter11,     12'h B0B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter12,     12'h B0C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter13,     12'h B0D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter14,     12'h B0E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter15,     12'h B0F, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter16,     12'h B10, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter17,     12'h B11, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter18,     12'h B12, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter19,     12'h B13, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter20,     12'h B14, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter21,     12'h B15, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter22,     12'h B16, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter23,     12'h B17, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter24,     12'h B18, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter25,     12'h B19, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter26,     12'h B1A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter27,     12'h B1B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter28,     12'h B1C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter29,     12'h B1D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter30,     12'h B1E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter31,     12'h B1F, 32'h 0000_0000)			\
 											\
 	`NERV_CSR_REG_MRW(mcycleh,           12'h B80, 32'h 0000_0000)			\
 	`NERV_CSR_REG_MRW(minstreth,         12'h B82, 32'h 0000_0000)			\
 											\
-	`NERV_CSR_VAL_MRO(mhpmcounter3h,     12'h B83, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter4h,     12'h B84, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter5h,     12'h B85, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter6h,     12'h B86, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter7h,     12'h B87, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter8h,     12'h B88, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter9h,     12'h B89, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter10h,    12'h B8A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter11h,    12'h B8B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter12h,    12'h B8C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter13h,    12'h B8D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter14h,    12'h B8E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter15h,    12'h B8F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter16h,    12'h B90, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter17h,    12'h B91, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter18h,    12'h B92, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter19h,    12'h B93, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter20h,    12'h B94, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter21h,    12'h B95, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter22h,    12'h B96, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter23h,    12'h B97, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter24h,    12'h B98, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter25h,    12'h B99, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter26h,    12'h B9A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter27h,    12'h B9B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter28h,    12'h B9C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter29h,    12'h B9D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter30h,    12'h B9E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmcounter31h,    12'h B9F, 32'h 0000_0000)
+	`NERV_CSR_VAL_MRW(mhpmcounter3h,     12'h B83, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter4h,     12'h B84, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter5h,     12'h B85, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter6h,     12'h B86, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter7h,     12'h B87, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter8h,     12'h B88, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter9h,     12'h B89, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter10h,    12'h B8A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter11h,    12'h B8B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter12h,    12'h B8C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter13h,    12'h B8D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter14h,    12'h B8E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter15h,    12'h B8F, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter16h,    12'h B90, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter17h,    12'h B91, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter18h,    12'h B92, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter19h,    12'h B93, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter20h,    12'h B94, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter21h,    12'h B95, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter22h,    12'h B96, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter23h,    12'h B97, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter24h,    12'h B98, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter25h,    12'h B99, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter26h,    12'h B9A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter27h,    12'h B9B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter28h,    12'h B9C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter29h,    12'h B9D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter30h,    12'h B9E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmcounter31h,    12'h B9F, 32'h 0000_0000)
 
 `define NERV_COUNTER_SETUP_CSRS /* Machine Counter Setup CSRs */			\
 	/* mcountinhibit is optional */							\
 /*	`NERV_CSR_VAL_MRW(mcountinhibit,     12'h 320, 32'h 0000_0000) */		\
 											\
 	/* mhpmevent3..31 can be readonly 0 */						\
-	`NERV_CSR_VAL_MRO(mhpmevent3,        12'h 323, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent4,        12'h 324, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent5,        12'h 325, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent6,        12'h 326, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent7,        12'h 327, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent8,        12'h 328, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent9,        12'h 329, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent10,       12'h 32A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent11,       12'h 32B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent12,       12'h 32C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent13,       12'h 32D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent14,       12'h 32E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent15,       12'h 32F, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent16,       12'h 330, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent17,       12'h 331, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent18,       12'h 332, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent19,       12'h 333, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent20,       12'h 334, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent21,       12'h 335, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent22,       12'h 336, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent23,       12'h 337, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent24,       12'h 338, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent25,       12'h 339, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent26,       12'h 33A, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent27,       12'h 33B, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent28,       12'h 33C, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent29,       12'h 33D, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent30,       12'h 33E, 32'h 0000_0000)			\
-	`NERV_CSR_VAL_MRO(mhpmevent31,       12'h 33F, 32'h 0000_0000)
+	`NERV_CSR_VAL_MRW(mhpmevent3,        12'h 323, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent4,        12'h 324, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent5,        12'h 325, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent6,        12'h 326, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent7,        12'h 327, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent8,        12'h 328, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent9,        12'h 329, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent10,       12'h 32A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent11,       12'h 32B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent12,       12'h 32C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent13,       12'h 32D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent14,       12'h 32E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent15,       12'h 32F, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent16,       12'h 330, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent17,       12'h 331, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent18,       12'h 332, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent19,       12'h 333, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent20,       12'h 334, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent21,       12'h 335, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent22,       12'h 336, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent23,       12'h 337, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent24,       12'h 338, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent25,       12'h 339, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent26,       12'h 33A, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent27,       12'h 33B, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent28,       12'h 33C, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent29,       12'h 33D, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent30,       12'h 33E, 32'h 0000_0000)			\
+	`NERV_CSR_VAL_MRW(mhpmevent31,       12'h 33F, 32'h 0000_0000)
 
 `define NERV_CUSTOM_CSRS /* Custom CSR for testing */					\
 	`NERV_CSR_REG_MRW(custom,            12'h BC0, 32'h 0000_0000)			\
@@ -567,6 +567,7 @@ module nerv #(
 
 `define NERV_CSR_VAL_MRW(NAME, ADDR, VALUE)				\
 	wire csr_``NAME``_sel = csr_mode && csr_addr == ADDR;		\
+	wire [31:0] csr_``NAME``_wdata = csr_``NAME``_sel ? csr_next : csr_``NAME``_value; \
 	localparam [31:0] csr_``NAME``_value = VALUE;
 
 `define NERV_CSR_VAL_MRO(NAME, ADDR, VALUE)				\
@@ -1116,13 +1117,13 @@ module nerv #(
 			rvfi_csr_``NAME``_wdata <= csr_``NAME``_wdata;
 
 `define NERV_CSR_VAL_MRW(NAME, ADDR, VALUE) \
+	`NERV_CSR_REG_MRW(NAME, ADDR, VALUE)
+
+`define NERV_CSR_VAL_MRO(NAME, ADDR, VALUE) \
 			rvfi_csr_``NAME``_rmask <= 32'h ffff_ffff;	\
 			rvfi_csr_``NAME``_wmask <= 32'h ffff_ffff;	\
 			rvfi_csr_``NAME``_rdata <= csr_``NAME``_value;	\
 			rvfi_csr_``NAME``_wdata <= csr_``NAME``_value;
-
-`define NERV_CSR_VAL_MRO(NAME, ADDR, VALUE) \
-	`NERV_CSR_VAL_MRW(NAME, ADDR, VALUE)
 
 `NERV_CSRS
 `undef NERV_CSR_REG_MRW

--- a/sections.lds
+++ b/sections.lds
@@ -12,6 +12,8 @@ SECTIONS {
         . = ALIGN(4);
         *(.text)           /* .text sections (code) */
         *(.text*)          /* .text* sections (code) */
+        PROVIDE(__vector_start = .);
+        KEEP(*(.vectors));
         *(.rodata)         /* .rodata sections (constants, strings, etc.) */
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
         *(.srodata)        /* .rodata sections (constants, strings, etc.) */

--- a/testbench.gtkw
+++ b/testbench.gtkw
@@ -68,7 +68,7 @@ testbench.dut.rs2_value[31:0]
 testbench.dut.next_wr
 @22
 testbench.dut.next_rd[31:0]
-@c00201
+@c00200
 -registers
 @22
 testbench.dut.dbg_reg_x0[31:0]
@@ -103,7 +103,7 @@ testbench.dut.dbg_reg_x28[31:0]
 testbench.dut.dbg_reg_x29[31:0]
 testbench.dut.dbg_reg_x30[31:0]
 testbench.dut.dbg_reg_x31[31:0]
-@1401201
+@1401200
 -registers
 @200
 -
@@ -129,5 +129,23 @@ testbench.dut.mem_wr_enable
 testbench.dut.mem_wr_addr[31:0]
 testbench.dut.mem_wr_data[31:0]
 testbench.dut.mem_wr_strb[3:0]
+@200
+-
+-CSRs
+@24
+testbench.dut.csr_mcycle_value[31:0]
+testbench.dut.csr_minstret_value[31:0]
+@28
+testbench.dut.csr_mstatus_value[31:0]
+@22
+testbench.dut.csr_mtvec_value[31:0]
+testbench.dut.csr_mcause_value[31:0]
+testbench.dut.csr_mepc_value[31:0]
+@201
+-Interrupts
+@22
+testbench.dut.irq[31:0]
+testbench.dut.irq_en[31:0]
+testbench.dut.irq_num[4:0]
 [pattern_trace] 1
 [pattern_trace] 0

--- a/testbench.sv
+++ b/testbench.sv
@@ -120,6 +120,7 @@ nerv dut (
 	.reset(reset),
 	.stall(stall),
 	.trap(trap),
+	.nmi(1'b0),
 
 	.imem_addr(imem_addr),
 	.imem_data(stall ? 32'bx : imem_data),

--- a/testbench.sv
+++ b/testbench.sv
@@ -36,6 +36,8 @@ wire [ 3:0] dmem_wstrb;
 wire [31:0] dmem_wdata;
 reg  [31:0] dmem_rdata;
 
+reg  [31:0] irq = 'b0;
+
 always #5 clock = clock === 1'b0;
 always @(posedge clock) reset <= 0;
 
@@ -120,7 +122,6 @@ nerv dut (
 	.reset(reset),
 	.stall(stall),
 	.trap(trap),
-	.nmi(1'b0),
 
 	.imem_addr(imem_addr),
 	.imem_data(stall ? 32'bx : imem_data),
@@ -129,7 +130,9 @@ nerv dut (
 	.dmem_addr(dmem_addr),
 	.dmem_wstrb(dmem_wstrb),
 	.dmem_wdata(dmem_wdata),
-	.dmem_rdata(stall ? 32'bx : dmem_rdata)
+	.dmem_rdata(stall ? 32'bx : dmem_rdata),
+
+	.irq(irq)
 );
 
 reg [31:0] cycles = 0;

--- a/testbench.sv
+++ b/testbench.sv
@@ -132,6 +132,11 @@ nerv dut (
 	.dmem_wdata(dmem_wdata),
 	.dmem_rdata(stall ? 32'bx : dmem_rdata),
 
+`ifdef NERV_FAULT
+	.imem_fault(1'b0),
+	.dmem_fault(1'b0),
+`endif
+
 	.irq(irq)
 );
 

--- a/trace.gtkw
+++ b/trace.gtkw
@@ -127,5 +127,27 @@ rvfi_testbench.checker_inst.rvfi_mem_wdata[31:0]
 rvfi_testbench.checker_inst.rvfi_mem_wmask[3:0]
 @1401200
 -rvfi
+@c00200
+-csr
+@28
+rvfi_testbench.checker_inst.check
+rvfi_testbench.checker_inst.csr_write_valid
+rvfi_testbench.checker_inst.csr_read_valid
+rvfi_testbench.checker_inst.csr_written
+rvfi_testbench.checker_inst.csr_read_shadowed
+rvfi_testbench.checker_inst.csr_mode_shadow
+@22
+rvfi_testbench.checker_inst.csr_mode[1:0]
+rvfi_testbench.checker_inst.csr_insn_addr[11:0]
+rvfi_testbench.checker_inst.csr_insn_rdata[31:0]
+rvfi_testbench.checker_inst.csr_insn_rmask[31:0]
+rvfi_testbench.checker_inst.csr_insn_wdata[31:0]
+rvfi_testbench.checker_inst.csr_insn_wmask[31:0]
+rvfi_testbench.checker_inst.rsval_shadow[31:0]
+rvfi_testbench.checker_inst.wdata_shadow[31:0]
+rvfi_testbench.checker_inst.rdata_shadow[31:0]
+rvfi_testbench.checker_inst.csr_mode_shadow[1:0]
+@1401200
+-csr
 [pattern_trace] 1
 [pattern_trace] 0

--- a/vectors.s
+++ b/vectors.s
@@ -1,0 +1,134 @@
+/*
+* Copyright 2019 ETH Zürich and University of Bologna
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+.section .vectors, "ax"
+.option norvc
+vector_table:
+	j sw_irq_handler         /* 0 */
+	j __no_irq_handler       /* 1 */
+	j __no_irq_handler       /* 2 */
+	j software_irq_handler   /* 3 */
+	j __no_irq_handler       /* 4 */
+	j __no_irq_handler       /* 5 */
+	j __no_irq_handler       /* 6 */
+	j timer_irq_handler      /* 7 */
+	j __no_irq_handler       /* 8 */
+	j __no_irq_handler       /* 9 */
+	j __no_irq_handler       /* 10 */
+	j external_irq_handler   /* 11 */
+	j __no_irq_handler       /* 12 */
+	j __no_irq_handler       /* 13 */
+	j __no_irq_handler       /* 14 */
+	j __no_irq_handler       /* 15 */
+	j __no_irq_handler       /* 16 */
+	j __no_irq_handler       /* 17 */
+	j __no_irq_handler       /* 18 */
+	j __no_irq_handler       /* 19 */
+	j __no_irq_handler       /* 20 */
+	j __no_irq_handler       /* 21 */
+	j __no_irq_handler       /* 22 */
+	j __no_irq_handler       /* 23 */
+	j __no_irq_handler       /* 24 */
+	j __no_irq_handler       /* 25 */
+	j __no_irq_handler       /* 26 */
+	j __no_irq_handler       /* 27 */
+	j __no_irq_handler       /* 28 */
+	j __no_irq_handler       /* 29 */
+	j __no_irq_handler       /* 30 */
+	j __no_irq_handler       /* 31 */
+
+.section .text.vecs
+/* exception handling */
+__no_irq_handler:
+	la a0, no_exception_handler_msg
+	jal ra, puts
+	j __no_irq_handler
+
+
+sw_irq_handler:
+	csrr t0, mcause
+	slli t0, t0, 1  /* shift off the high bit */
+	srli t0, t0, 1
+	li t1, 2
+	beq t0, t1, handle_illegal_insn
+	li t1, 11
+	beq t0, t1, handle_ecall
+	li t1, 3
+	beq t0, t1, handle_ebreak
+	j handle_unknown
+
+handle_ecall:
+	la a0, ecall_msg
+	jal ra, puts
+	j end_handler
+
+handle_ebreak:
+	la a0, ebreak_msg
+	jal ra, puts
+	j end_handler
+
+handle_illegal_insn:
+	la a0, illegal_insn_msg
+	jal ra, puts
+	j end_handler
+
+handle_unknown:
+	la a0, unknown_msg
+	jal ra, puts
+	j end_handler
+
+end_handler:
+	csrr a0, mepc
+	addi a0, a0, 4
+	csrw mepc, a0
+	mret
+/* this interrupt can be generated for verification purposes, random or when the PC is equal to a given value*/
+verification_irq_handler:
+	mret
+
+software_irq_handler:
+	la a0, software_irq_msg
+	jal ra, puts
+	mret
+
+timer_irq_handler:
+	la a0, timer_irq_msg
+	jal ra, puts
+	mret
+
+external_irq_handler:
+	la a0, external_irq_msg
+	jal ra, puts
+	mret
+
+
+.section .rodata
+illegal_insn_msg:
+	.string "illegal instruction exception handler entered\n"
+ecall_msg:
+	.string "ecall exception handler entered\n"
+ebreak_msg:
+	.string "ebreak exception handler entered\n"
+unknown_msg:
+	.string "unknown exception handler entered\n"
+no_exception_handler_msg:
+	.string "no exception handler installed\n"
+software_irq_msg:
+	.string "software irq handler entered\n"
+timer_irq_msg:
+	.string "timer irq handler entered\n"
+external_irq_msg:
+	.string "external irq handler entered\n"

--- a/wrapper.sv
+++ b/wrapper.sv
@@ -25,6 +25,7 @@ module rvfi_wrapper (
 	(* keep *) `rvformal_rand_reg stall;
 	(* keep *) `rvformal_rand_reg [31:0] imem_data;
 	(* keep *) `rvformal_rand_reg [31:0] dmem_rdata;
+	(* keep *) `rvformal_rand_reg nmi;
 
 	(* keep *) wire trap;
 
@@ -40,6 +41,7 @@ module rvfi_wrapper (
 		.reset      (reset    ),
 		.stall      (stall    ),
 		.trap       (trap     ),
+		.nmi        (nmi      ),
 
 		.imem_addr  (imem_addr ),
 		.imem_data  (imem_data ),

--- a/wrapper.sv
+++ b/wrapper.sv
@@ -25,7 +25,7 @@ module rvfi_wrapper (
 	(* keep *) `rvformal_rand_reg stall;
 	(* keep *) `rvformal_rand_reg [31:0] imem_data;
 	(* keep *) `rvformal_rand_reg [31:0] dmem_rdata;
-	(* keep *) `rvformal_rand_reg nmi;
+	(* keep *) `rvformal_rand_reg [31:0] irq;
 
 	(* keep *) wire trap;
 
@@ -41,7 +41,6 @@ module rvfi_wrapper (
 		.reset      (reset    ),
 		.stall      (stall    ),
 		.trap       (trap     ),
-		.nmi        (nmi      ),
 
 		.imem_addr  (imem_addr ),
 		.imem_data  (imem_data ),
@@ -51,6 +50,7 @@ module rvfi_wrapper (
 		.dmem_wstrb (dmem_wstrb),
 		.dmem_wdata (dmem_wdata),
 		.dmem_rdata (dmem_rdata),
+		.irq (irq),
 
 		`RVFI_CONN32
 	);

--- a/wrapper.sv
+++ b/wrapper.sv
@@ -21,6 +21,7 @@ module rvfi_wrapper (
 	input         clock,
 	input         reset,
 	`RVFI_OUTPUTS
+	`RVFI_BUS_OUTPUTS
 );
 	(* keep *) `rvformal_rand_reg stall;
 	(* keep *) `rvformal_rand_reg [31:0] imem_data;
@@ -54,6 +55,67 @@ module rvfi_wrapper (
 
 		`RVFI_CONN32
 	);
+
+`ifdef RISCV_FORMAL_BUS
+
+`define RISCV_FORMAL_CHANNEL_SIGNAL(channels, width, name) \
+	(* keep *) reg [(width) - 1:0] imem_``name; assign rvfi_``name[0 * (width) +: (width)] = imem_``name;
+`RVFI_BUS_SIGNALS
+`undef RISCV_FORMAL_CHANNEL_SIGNAL
+
+`define RISCV_FORMAL_CHANNEL_SIGNAL(channels, width, name) \
+	(* keep *) reg [(width) - 1:0] dmem_``name; assign rvfi_``name[1 * (width) +: (width)] = dmem_``name;
+`RVFI_BUS_SIGNALS
+`undef RISCV_FORMAL_CHANNEL_SIGNAL
+
+
+	reg [31:0] imem_addr_q;
+
+	always @(posedge clock) begin
+		if (!stall)
+			imem_addr_q <= imem_addr;
+	end
+
+	always @* begin
+		imem_bus_addr  = imem_addr_q;
+		imem_bus_insn  = 1;
+		imem_bus_data  = 0;
+		imem_bus_rmask = 4'b1111;
+		imem_bus_wmask = 4'b0000;
+		imem_bus_rdata = imem_data;
+		imem_bus_wdata = 0;
+		imem_bus_valid = !stall;
+	end;
+
+	reg        dmem_valid_q;
+	reg [31:0] dmem_addr_q;
+	reg [ 3:0] dmem_wstrb_q;
+	reg [31:0] dmem_wdata_q;
+
+
+	(* keep *) `rvformal_rand_reg [31:0] next_dmem_rdata;
+	reg [31:0] next_dmem_rdata_q;
+
+	always @(posedge clock) begin
+		if (!stall)
+			next_dmem_rdata_q <= next_dmem_rdata;
+	end
+
+	always @* begin
+		if (!stall)
+			assume (dmem_rdata == next_dmem_rdata_q);
+
+		dmem_bus_addr  = dmem_addr;
+		dmem_bus_insn  = 0;
+		dmem_bus_data  = 1;
+		dmem_bus_rmask = dmem_wstrb ? 4'b0000 : 4'b1111;
+		dmem_bus_wmask = dmem_wstrb;
+		dmem_bus_rdata = next_dmem_rdata;
+		dmem_bus_wdata = dmem_wdata;
+		dmem_bus_valid = !stall && dmem_valid;
+	end;
+
+`endif
 
 `ifdef NERV_FAIRNESS
 	reg [2:0] stalled = 0;


### PR DESCRIPTION
Minimum working example to meet CSR requirements.
Includes interrupt handling changes.
See also YosysHQ/riscv-formal#14