### PR TITLE
using CFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,13 @@ TOOLCHAIN_PREFIX?=riscv64-unknown-elf-
 
 RISCV_ARCH?=rv32i$(shell $(TOOLCHAIN_PREFIX)as -march=rv32i_zicsr --dump-config 2>/dev/null && echo _zicsr)
 
+CFLAGS?=-mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib
+
 test: firmware.hex testbench
 	vvp -N testbench +vcd
 
 firmware.elf: firmware.s vectors.s firmware.c
-	$(TOOLCHAIN_PREFIX)gcc -march=$(RISCV_ARCH) -mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $^
+	$(TOOLCHAIN_PREFIX)gcc -march=$(RISCV_ARCH) $(CFLAGS) -o $@ $^
 
 firmware.hex: firmware.elf
 	$(TOOLCHAIN_PREFIX)objcopy -O verilog $< $@

--- a/axi_cache/Makefile
+++ b/axi_cache/Makefile
@@ -28,6 +28,8 @@ RISCV_ARCH?=rv32i$(shell $(TOOLCHAIN_PREFIX)as -march=rv32i_zicsr --dump-config 
 
 CACHE_SOURCES:=nerv_axi_cache.sv nerv_axi_cache_icache.sv nerv_axi_cache_dcache.sv
 
+CFLAGS?=-mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,../sections.lds,--strip-debug -ffreestanding -nostdlib
+
 .PHONY: test_internal test_axi verify_axi verify_axi_cover checks_internal checks_axi all
 
 test_internal: firmware.hex testbench_internal
@@ -43,7 +45,7 @@ verify_axi_cover: SVA-AXI4-FVIP verify_axi.sby verify_axi.sv
 	sby -f verify_axi.sby cover
 
 firmware.elf: ../firmware.s ../vectors.s firmware.c
-	$(TOOLCHAIN_PREFIX)gcc -march=$(RISCV_ARCH) -mabi=ilp32 -Os -Wall -Wextra -Wl,-Bstatic,-T,../sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $^
+	$(TOOLCHAIN_PREFIX)gcc -march=$(RISCV_ARCH) $(CFLAGS) -o $@ $^
 
 firmware.hex: firmware.elf
 	$(TOOLCHAIN_PREFIX)objcopy -O verilog $< $@


### PR DESCRIPTION
I updated the `Makefile`s to use `CFLAGS` so I can override them while calling make, to compile the with debug symbols in the EFL file. The change should be backward compatible and have no effect on existing use cases.